### PR TITLE
Add default constructor

### DIFF
--- a/lib/EmbedDB-Utility/embedDBUtility.c
+++ b/lib/EmbedDB-Utility/embedDBUtility.c
@@ -11,6 +11,59 @@
 
 #include <string.h>
 
+embedDBState *defaultInitializedState() {
+    embedDBState *state = calloc(1, sizeof(embedDBState));
+    if (state == NULL) {
+#ifdef PRINT_ERRORS
+        printf("Failed to allocate memory for state.\n");
+#endif
+        return NULL;
+    }
+
+    state->keySize = 4;
+    state->dataSize = 12;
+    state->pageSize = 512;
+    state->numSplinePoints = 300;
+    state->bitmapSize = 1;
+    state->bufferSizeInBlocks = 4;
+    state->buffer = malloc((size_t)state->bufferSizeInBlocks * state->pageSize);
+
+    /* Address level parameters */
+    state->numDataPages = 20000;  // Enough for 620,000 records
+    state->numIndexPages = 44;    // Enough for 676,544 records
+    state->eraseSizeInPages = 4;
+
+    char dataPath[] = "dataFile.bin", indexPath[] = "indexFile.bin";
+    state->fileInterface = getSDInterface();
+    state->dataFile = setupSDFile(dataPath);
+    state->indexFile = setupSDFile(indexPath);
+
+    state->parameters = EMBEDDB_USE_BMAP | EMBEDDB_USE_INDEX | EMBEDDB_RESET_DATA;
+    state->bitmapSize = 1;
+
+    /* Setup for data and bitmap comparison functions */
+    state->inBitmap = inBitmapInt8;
+    state->updateBitmap = updateBitmapInt8;
+    state->buildBitmapFromRange = buildBitmapInt8FromRange;
+    state->compareKey = int32Comparator;
+    state->compareData = int32Comparator;
+
+    /* Initialize embedDB structure */
+    if (embedDBInit(state, 1) != 0) {
+#ifdef PRINT_ERRORS
+        printf("Initialization error.\n");
+#endif
+        free(state->buffer);
+        free(state->fileInterface);
+        tearDownSDFile(state->dataFile);
+        tearDownSDFile(state->indexFile);
+        free(state);
+        return NULL;
+    }
+
+    return state;
+}
+
 /* A bitmap with 8 buckets (bits). Range 0 to 100. */
 void updateBitmapInt8(void *data, void *bm) {
     // Note: Assuming int key is right at the start of the data record

--- a/lib/EmbedDB-Utility/embedDBUtility.h
+++ b/lib/EmbedDB-Utility/embedDBUtility.h
@@ -17,6 +17,13 @@ extern "C" {
 #include <stdint.h>
 #include <string.h>
 
+#include "../../src/embedDB/embedDB.h"
+#include "SDFileInterface.h"
+
+/* Constructors */
+embedDBState *defaultInitializedState();
+
+/* Bitmap Functions */
 void updateBitmapInt8(void *data, void *bm);
 void buildBitmapInt8FromRange(void *min, void *max, void *bm);
 int8_t inBitmapInt8(void *data, void *bm);
@@ -26,6 +33,8 @@ void buildBitmapInt16FromRange(void *min, void *max, void *bm);
 void updateBitmapInt64(void *data, void *bm);
 int8_t inBitmapInt64(void *data, void *bm);
 void buildBitmapInt64FromRange(void *min, void *max, void *bm);
+
+/* Recordwise functions */
 int8_t int32Comparator(void *a, void *b);
 int8_t int64Comparator(void *a, void *b);
 


### PR DESCRIPTION
A port of the default constructor added in the desktop repo. Only difference is the difference of imports and using the SD file interface with a different path.

Closes #32 