### PR TITLE
Fix Issues with Unit Tests Failing on Main

### DIFF
--- a/lib/EmbedDB-Utility/embedDBUtility.c
+++ b/lib/EmbedDB-Utility/embedDBUtility.c
@@ -40,59 +40,6 @@
 
 #include <string.h>
 
-embedDBState *defaultInitializedState() {
-    embedDBState *state = calloc(1, sizeof(embedDBState));
-    if (state == NULL) {
-#ifdef PRINT_ERRORS
-        printf("Failed to allocate memory for state.\n");
-#endif
-        return NULL;
-    }
-
-    state->keySize = 4;
-    state->dataSize = 12;
-    state->pageSize = 512;
-    state->numSplinePoints = 300;
-    state->bitmapSize = 1;
-    state->bufferSizeInBlocks = 4;
-    state->buffer = malloc((size_t)state->bufferSizeInBlocks * state->pageSize);
-
-    /* Address level parameters */
-    state->numDataPages = 20000;  // Enough for 620,000 records
-    state->numIndexPages = 44;    // Enough for 676,544 records
-    state->eraseSizeInPages = 4;
-
-    char dataPath[] = "dataFile.bin", indexPath[] = "indexFile.bin";
-    state->fileInterface = getSDInterface();
-    state->dataFile = setupSDFile(dataPath);
-    state->indexFile = setupSDFile(indexPath);
-
-    state->parameters = EMBEDDB_USE_BMAP | EMBEDDB_USE_INDEX | EMBEDDB_RESET_DATA;
-    state->bitmapSize = 1;
-
-    /* Setup for data and bitmap comparison functions */
-    state->inBitmap = inBitmapInt8;
-    state->updateBitmap = updateBitmapInt8;
-    state->buildBitmapFromRange = buildBitmapInt8FromRange;
-    state->compareKey = int32Comparator;
-    state->compareData = int32Comparator;
-
-    /* Initialize embedDB structure */
-    if (embedDBInit(state, 1) != 0) {
-#ifdef PRINT_ERRORS
-        printf("Initialization error.\n");
-#endif
-        free(state->buffer);
-        free(state->fileInterface);
-        tearDownSDFile(state->dataFile);
-        tearDownSDFile(state->indexFile);
-        free(state);
-        return NULL;
-    }
-
-    return state;
-}
-
 /* A bitmap with 8 buckets (bits). Range 0 to 100. */
 void updateBitmapInt8(void *data, void *bm) {
     // Note: Assuming int key is right at the start of the data record

--- a/lib/EmbedDB-Utility/embedDBUtility.h
+++ b/lib/EmbedDB-Utility/embedDBUtility.h
@@ -46,12 +46,6 @@ extern "C" {
 #include <stdint.h>
 #include <string.h>
 
-#include "../../src/embedDB/embedDB.h"
-#include "SDFileInterface.h"
-
-/* Constructors */
-embedDBState *defaultInitializedState();
-
 /* Bitmap Functions */
 void updateBitmapInt8(void *data, void *bm);
 void buildBitmapInt8FromRange(void *min, void *max, void *bm);

--- a/src/embedDB/embedDB.c
+++ b/src/embedDB/embedDB.c
@@ -44,8 +44,8 @@
 
 #include "../spline/radixspline.h"
 #include "../spline/spline.h"
-#include "serial_c_iface.h"
 #include "embedDBUtility.h"
+#include "serial_c_iface.h"
 
 /**
  * 0 = Modified binary search

--- a/src/embedDB/embedDB.h
+++ b/src/embedDB/embedDB.h
@@ -254,6 +254,13 @@ typedef struct {
  */
 int8_t embedDBInit(embedDBState *state, size_t indexMaxError);
 
+/* Constructors */
+/**
+ * @brief	Initialize embedDB structure with default parameters.
+ * @return	Returns an embedDB state with default values if successful, and NULL if not
+ */
+embedDBState *defaultInitializedState();
+
 /**
  * @brief   Prints the initialization stats of the given embedDB state
  * @param   state   embedDB state structure


### PR DESCRIPTION
### Description
- The unit test check was currently failing on main.
- The issue was due to the addition of the default constructor, which was put in the lib folder, but needs to be located in the `embedDB.c` file due to how PlatformIO builds projects.