### PR TITLE
Fix Compile Warnings with Default Constructor

### DIFF
--- a/src/embedDB/embedDB.c
+++ b/src/embedDB/embedDB.c
@@ -45,6 +45,7 @@
 #include "../spline/radixspline.h"
 #include "../spline/spline.h"
 #include "embedDBUtility.h"
+#include "SDFileInterface.h"
 #include "serial_c_iface.h"
 
 /**


### PR DESCRIPTION
### Description
- The default constructor needed another file included in EmbedDB to function properly.