### PR TITLE
Fix Bug Preventing Distribution Files from Running on Linux

### DIFF
--- a/amalgamation/amalgamation.py
+++ b/amalgamation/amalgamation.py
@@ -670,7 +670,7 @@ def amalgamate(
     if split_header_files:
         save_file(header + amalg_h, file_name, "h", save_directory)
         save_file(
-            '#include "./EmbedDB.h"\n' + header + amalg_c,
+            '#include "./embedDB.h"\n' + header + amalg_c,
             file_name,
             "cpp" if isCpp else "c",
             save_directory,


### PR DESCRIPTION
### Description
- The distribution file has only been tested on Windows so far, but on Linux files are case sensitive, so the inclusion of the header file is failing on Linux