### PR TITLE
Add Ability to Run Distribution Version of EmbedDB on Desktop

### DIFF
--- a/.github/workflows/build_embedDB_distribution_desktop.yml
+++ b/.github/workflows/build_embedDB_distribution_desktop.yml
@@ -2,7 +2,7 @@ name: Build Run and Test EmbedDB Distribution Desktop
 
 on:
     push:
-    #   branches: ["update-distribution"]
+        branches: ["update-distribution"]
 
 jobs:
     build_platformIO:

--- a/.github/workflows/build_embedDB_distribution_desktop.yml
+++ b/.github/workflows/build_embedDB_distribution_desktop.yml
@@ -1,0 +1,141 @@
+name: Build Run and Test EmbedDB Distribution Desktop
+
+on:
+    push:
+      branches: ["update-distribution"]
+
+jobs:
+    build_platformIO:
+        name: Build and Run EmbedDB Distribution Using PlatformIO
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+        
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Set environment variable
+              run: |
+                if [[ "$RUNNER_OS" == "Windows" ]]; then
+                    echo "EXPORT_COMMAND=set" >> $GITHUB_ENV
+                else
+                    echo "EXPORT_COMMAND=export" >> $GITHUB_ENV
+                fi
+              shell: bash
+
+            - name: Set up Python
+              uses: actions/setup-python@v4
+            
+            - name: Install PlatformIO
+              run: |
+                python -m pip install --upgrade pip
+                python -m pip install platformio
+
+            - name: Run EmbedDB Distribution Example
+              run: |
+                    pio run -e desktop-dist -t fullclean
+                    ${{ env.EXPORT_COMMAND }} PLATFORMIO_BUILD_FLAGS="-DWHICH_PROGRAM=0 -lm"
+                    pio run -e desktop-dist -t exec
+
+            - name: Run EmbedDB Distribution Sequential Data Benchmark
+              run: |
+                    pio run -e desktop-dist -t fullclean
+                    ${{ env.EXPORT_COMMAND }} PLATFORMIO_BUILD_FLAGS="-DWHICH_PROGRAM=1 -lm"
+                    pio run -e desktop-dist -t exec
+            
+            - name: Run EmbedDB Distribution Variable Data Benchmark
+              run: |
+                    pio run -e desktop-dist -t fullclean
+                    ${{ env.EXPORT_COMMAND }} PLATFORMIO_BUILD_FLAGS="-DWHICH_PROGRAM=2 -lm"
+                    pio run -e desktop-dist -t exec
+                
+            - name: Run EmbedDB Distribution Query Interface Benchmark
+              run: |
+                    pio run -e desktop-dist -t fullclean
+                    ${{ env.EXPORT_COMMAND }} PLATFORMIO_BUILD_FLAGS="-DWHICH_PROGRAM=3 -lm"
+                    pio run -e desktop-dist -t exec
+        
+    test_platformIO:
+        name: Test EmbedDB Distribution using PlatformIO
+        needs: build_platformIO
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+        
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Python
+              uses: actions/setup-python@v4
+            - name: Install PlatformIO
+              run: |
+                python -m pip install --upgrade pip
+                python -m pip install platformio
+            - name: Run Tests
+              run: pio test -e desktop-dist --junit-output-path "results.xml"
+
+            - name: Publish Unit Test Results
+              if: matrix.os == 'ubuntu-latest'
+              uses: EnricoMi/publish-unit-test-result-action/composite@v2
+              with:
+                github_token: ${{ github.token }}
+                files: results.xml
+                check_name: PlatformIO Ubuntu Distribution Unit Test Results
+
+    build_make:
+        name: Build and Run EmbedDB Distribution using Makefile
+
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Run EmbedDB Distribution Example
+              run: | 
+                make clean
+                make dist
+
+            - name: Run EmbedDB Distribution Sequential Data Benchmark
+              run: |
+                make clean
+                make dist CFLAGS="-DWHICH_PROGRAM=1"
+
+            - name: Run EmbedDB Distribution Variable Data Benchmark
+              run: |
+                make clean
+                make dist CFLAGS="-DWHICH_PROGRAM=2"
+
+            - name: Run EmbedDB Distribution Query Interface Benchmark
+              run: |
+                make clean
+                make dist CFLAGS="-DWHICH_PROGRAM=3"
+
+    test_make:
+        name: Test EmbedDB Distribution using Makefile
+        needs: build_make
+
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+            
+        steps:
+          - uses: actions/checkout@v3
+        
+          - name: Get Submodules
+            run: git submodule update --init --recursive
+        
+          - name: Build and Run Distribution Unit Tests
+            run: make test-dist
+        
+          - name: Publish Unit Test Results
+            if: matrix.os == 'ubuntu-latest'
+            uses: EnricoMi/publish-unit-test-result-action/composite@v2
+            with:
+              github_token: ${{ github.token }}
+              files: ./build/results/*.xml
+              check_name: Makefile Ubuntu Distribution Unit Test Results

--- a/.github/workflows/build_embedDB_distribution_desktop.yml
+++ b/.github/workflows/build_embedDB_distribution_desktop.yml
@@ -2,7 +2,7 @@ name: Build Run and Test EmbedDB Distribution Desktop
 
 on:
     push:
-      branches: ["update-distribution"]
+    #   branches: ["update-distribution"]
 
 jobs:
     build_platformIO:

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,6 +1,6 @@
 ## Running EmbedDB on Desktop Platforms
 
-The EmbedDB project can be run on both Windows and Linux. This can be achieved using either PlatformIO or the included [makefile](../makefile). GCC must be installed on your system to run EmbedDB using either of these options. For Windows, follow this [tutorial](https://code.visualstudio.com/docs/cpp/config-mingw) to install GCC.
+The EmbedDB project can be run on desktop platforms (Windows and Linux). This can be achieved using either PlatformIO or the included [makefile](../makefile). GCC must be installed on your system to run EmbedDB using either of these options. For Windows, follow this [tutorial](https://code.visualstudio.com/docs/cpp/config-mingw) to install GCC, or use [WSL](https://learn.microsoft.com/en-us/windows/wsl/) to run EmbedDB on Windows.
 
 ### Running EmbedDB with PlatformIO
 
@@ -16,10 +16,36 @@ Running the unit tests can also be done with PlatformIO:
 
 ### Running EmbedDB with Makefile
 
-Make must be installed on your system in addition to GCC to run EmbedDB this way.
+GNU Make must be installed on your system in addition to GCC to run EmbedDB this way.
 
 The  included examples and benchmark files can be run with the command `make build`. By default, the [example](../src/embedDBExample.h) file will run. This can be changed either in the runner [file](../src/desktopMain.c) by changing the **WHICH_PROGRAM** macro. It can also be changed over the command line using the command `make build CFLAGS="-DWHICH_PROGRAM=NUM", with NUM being from 0 - 3.
 
 Unit tests for EmbedDB can also be run using the makefile.
 - Make sure the Git submodules for the EmbedDB repository are installed. This can be done with the command `git submodule update --init --recursive`. 
 - Then, run the command `make test`. This will run and output the results from the tests to a file called `results.xml` located in the [results](../build/results/) folder. This folder is automatically generated when the make command is run. This file is a JUnit style XML that summarizes the output from each test file.
+
+## Running EmbedDB Distribution Version on Desktop Platforms
+
+The [distribution](distribution.md) version of EmbedDB can also be run on desktop platforms. As with the regular version, GCC must be installed, and it can be run with both PlatformIO or the included Makefile.
+
+### Running EmbedDB Distribution with PlatformIO
+
+Install the PlatformIO extension for Visual Studio Code or the PlatformIO CMD using the [installation instructions](https://platformio.org/install/).
+- If you installed PlatformIO using the extension, you can click on the PlatformIO icon on the sidebar, then select *Desktop-Dist > General > Upload*.
+- If you are running from the command line, run the command `pio run -e desktop-dist --target exec`.
+
+This will run the example file we have included for EmbedDB. There are additional benchmarking files which can be run. Change the **WHICH_PROGRAM** macro in the desktop runner [file](../src/desktopMain.c) to select one of the benchmarking files.
+
+Running the unit tests can also be done with PlatformIO:
+- If you installed PlatformIO using the extension, click the PlatformIO icon on the sidebar, and then select *Desktop-Dist > Advanced > Test*
+- Using the command line, run the command `pio test -e desktop-dist -vv` .
+
+### Running EmbedDB Distribution with Makefile
+
+GNU Make must be installed on your system in addition to GCC to run EmbedDB this way.
+
+The included examples and benchmark files can be run with the command `make dist`. By default, the [example](../src/embedDBExample.h) file will run. This can be changed either in the runner [file](../src/desktopMain.c) by changing the **WHICH_PROGRAM** macro. It can also be changed over the command line using the command `make build CFLAGS="-DWHICH_PROGRAM=NUM", with NUM being from 0 - 3.
+
+Unit tests for EmbedDB can also be run using the makefile.
+- Make sure the Git submodules for the EmbedDB repository are installed. This can be done with the command `git submodule update --init --recursive`. 
+- Then, run the command `make test-dist`. This will run and output the results from the tests to a file called `results.xml` located in the [results](../build/results/) folder. This folder is automatically generated when the make command is run. This file is a JUnit style XML that summarizes the output from each test file.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,16 +1,28 @@
 
-# EmbedDB Distribution
+## EmbedDB Distribution
 
 The EmbedDB project is also conviently packaged in to a distribution version consisting of one header file and one C source file. Currently, this only includes the EmbedDB code in the source folder, and not the SD or serial interface (a version that is ready with both those for Arduino is being worked on).
 
-To run the distribution code, you need to uncomment the following lines in the [configuration](../platformio.ini) file:
+To run the distribution code, make sure that PlatformIO is installed (see [setup](setup.md)). Then, select the PlatformIO extension on the sidebar. Under the *Project Tasks* choose *due-dist > General > Upload and Monitor* to compile, upload, and monitor the EmbedDB example using the distribution version of EmbedDB.
 
-```ini
-; Please uncomment these two lines below located at the top of the file
-[platformio]
-src_dir = distribution/
+Alternatively, useing the PlatformIO command line interface, run the following command from the root of the project:
+
+```cmd
+pio run -e due-dist -t upload -t monitor
 ```
 
-This will change the source directory for the project to the distribution version.
-
 Only the Arduino Due is currently configured to run the distribution version of the project. Use the `due-dist` environment in PlatformIO when running the distribution version of EmbedDB. Please see the [setup](setup.md) file for configuring the project for another board.
+
+For running the distribution version of EmbedDB on desktop platforms, see the [desktop](desktop.md) documentation.
+
+### EmbedDB Distribution Unit Tests
+
+The suite of unit tests for EmbedDB can also be run using the distribution version. 
+
+Using PlatformIO, select the PlatformIO extension on the sidebar. Then, choose *due-dist > Advanced > Test* to run the unit tests on the Arduino Due.
+
+Alternatively, useing the PlatformIO command line interface, run the following command from the root of the project:
+
+```cmd
+pio test -e due-dist -vv
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,8 @@
 # Project Setup
 
-Our project uses the [PlatformIO](platformio.org) extension for Visualt Studio Code to compile and run code on embedded devices.
+Our project uses the [PlatformIO](platformio.org) extension for Visualt Studio Code to compile and run code on embedded devices. This project can also be run on both Windows and Linux by following the [desktop setup](desktop.md) instructions.
+
+For information about running the distribution version of the code, see the [distribution](distribution.md) documentation.
 
 ## Requirements
 
@@ -15,10 +17,10 @@ The project includes files for interacting with an SD card on Arduino boards, an
 
 ## Running our Example File
 
-Once your board is configured with a main file, you can run the included [example file](../src/embedDBExample.h) by calling the `embedDBExample()` function from your main file. This file configures an instance of EmbedDB, and performs some basic functions with the database. To run the main file and example, please select the board you want to run in the PlatformIO extension, and under the *General* tab, choose the *Upload and Monitor* option. This will compile the code, upload it to your board, and monitor the serial connection for printed output.
+Once your board is configured with a main file, you can run the included [example file](../src/embedDBExample.h) by calling the `embedDBExample()` function from your main file. This file configures an instance of EmbedDB, and performs some basic functions with the database. To run the main file and example, please select the PlatformIO tab in the sidebar. Then, select the board you want to run the code on under the project tasks menu. For the Arduino Due, you would select *due > General > Upload and Monitor*. This will compile the code, upload it to your board, and monitor the serial connection for output during the runtime.
 
 ## Running the Unit Tests
 
 In order to run the unit tests for this project on a different board, you will need to implement a custom test setup file. Please see the [due](lib\Due\dueTestSetup.cpp) test setup file for an example.
 
-Once you have a custom setup file, you can run the unit tests through the *Advanced* tab under the board you configured.
+Once you have a custom setup file, you can run the unit tests through the *Advanced* tab under the board you configured. For example, to run unit tests on the Arduino Due, select *due > Advanced > Test*. 

--- a/makefile
+++ b/makefile
@@ -46,13 +46,11 @@ DISTRIBUTION_OBJECTS = $(PATHO)distribution.o
 
 TEST_FLAGS = -I. -I$(PATHU) -I $(PATHS) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -D TEST
 EXAMPLE_FLAGS = -I. -I$(PATHS) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -I$(PATH_DISTRIBUTION) -DPRINT_ERRORS
-TEST_DIST_FLAGS = -I. -I$(PATHU) -I$(PATH_FILE_INTERFACE) -I$(PATH_DISTRIBUTION) -DPRINT_ERRORS
+TEST_DIST_FLAGS = -I. -I$(PATHU) -I$(PATH_FILE_INTERFACE) -I$(PATH_DISTRIBUTION) -DDIST -D TEST
 
 override CFLAGS += $(if $(filter test-dist,$(MAKECMDGOALS)), $(TEST_DIST_FLAGS), $(if $(filter test,$(MAKECMDGOALS)),$(TEST_FLAGS),$(EXAMPLE_FLAGS)) )
 
 SRCT = $(wildcard $(PATHT)*/*.cpp)
-
-
 
 COMPILE=gcc -c
 LINK=gcc
@@ -82,12 +80,14 @@ test: $(BUILD_PATHS) $(RESULTS)
 	$(PYTHON) ./scripts/stylize_as_junit.py
 
 test-dist: $(BUILD_PATHS) $(RESULTS)
+	pip install -r requirements.txt -q
+	$(PYTHON) ./scripts/stylize_as_junit.py
 
 $(PATHR)%.testpass: $(PATHB)%.$(TARGET_EXTENSION)
 	$(MKDIR) $(@D)
 	-./$< > $@ 2>&1
 
-$(PATHB)test%.$(TARGET_EXTENSION): $(PATHO)test%.o $(if $(filter test-dist,$(MAKECMDGOALS)), $(DISTRIBUTION_OBJECTS), $(EMBEDDB_OBJECTS) $(QUERY_OBJECTS)) $(EMBEDDB_FILE_INTERFACE) $(PATHO)unity.o #$(PATHD)Test%.d
+$(PATHB)test%.$(TARGET_EXTENSION): $(PATHO)test%.o $(if $(filter test-dist,$(MAKECMDGOALS)), $(DISTRIBUTION_OBJECTS), $(EMBEDDB_OBJECTS) $(QUERY_OBJECTS)) $(EMBEDDB_FILE_INTERFACE) $(PATHO)unity.o
 	$(MKDIR) $(@D)
 	$(LINK) -o $@ $^ $(MATH)
 
@@ -95,20 +95,17 @@ $(PATHO)%.o:: $(PATHT)%.cpp
 	$(MKDIR) $(@D)
 	$(COMPILE) $(CFLAGS) $< -o $@
 
-$(PATHO)distribution.o:: $(PATH_DISTRIBUTION)embedDB.c
-	$(COMPILE) $(CFLAGS) $< -o $@
+$(PATHO)distribution.o: $(PATH_DISTRIBUTION)embedDB.c
+	$(COMPILE) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -DPRINT_ERRORS -I$(PATH_DISTRIBUTION) $< -o $@
 
 $(PATHO)%.o:: $(PATHS)%.c
 	$(COMPILE) $(CFLAGS) $< -o $@
-	
+
 $(PATHO)%.o:: $(PATHSPLINE)%.c
 	$(COMPILE) $(CFLAGS) $< -o $@
 
 $(PATHO)%.o:: $(PATH_EMBEDDB)%.c
 	$(COMPILE) $(CFLAGS) $< -o $@
-
-$(PATHO)%.o:: $(PATH_DISTRIBUTION)%.c
-	$(COMPILE) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -DPRINT_ERRORS -I$(PATH_DISTRIBUTION) $< -o $@
 
 $(PATHO)%.o:: $(PATH_UTILITY)%.c
 	$(COMPILE) $(CFLAGS) $< -o $@

--- a/makefile
+++ b/makefile
@@ -27,6 +27,7 @@ PATHSPLINE = src/spline/
 PATH_QUERY = src/query-interface/
 PATH_UTILITY = lib/EmbedDB-Utility/
 PATH_FILE_INTERFACE = lib/Desktop-File-Interface/
+PATH_DISTRIBUTION = lib/Distribution/
 
 PATHT = test/
 PATHB = build/
@@ -43,7 +44,7 @@ QUERY_OBJECTS = $(PATHO)schema.o $(PATHO)advancedQueries.o
 
 TEST_FLAGS = -I. -I $(PATHU) -I $(PATHS) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -D TEST
 
-EXAMPLE_FLAGS = -I. -I$(PATHS) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -D PRINT_ERRORS
+EXAMPLE_FLAGS = -I. -I$(PATHS) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -I$(PATH_DISTRIBUTION) -D PRINT_ERRORS
 
 override CFLAGS += $(if $(filter test,$(MAKECMDGOALS)),$(TEST_FLAGS),$(EXAMPLE_FLAGS))
 
@@ -90,6 +91,9 @@ $(PATHO)%.o:: $(PATHSPLINE)%.c
 
 $(PATHO)%.o:: $(PATH_EMBEDDB)%.c
 	$(COMPILE) $(CFLAGS) $< -o $@
+
+$(PATHO)%.o:: $(PATH_DISTRIBUTION)%.c
+	$(COMPILE) -I$(PATH_UTILITY) -I$(PATH_FILE_INTERFACE) -DPRINT_ERRORS -I$(PATH_DISTRIBUTION) $< -o $@
 
 $(PATHO)%.o:: $(PATH_UTILITY)%.c
 	$(COMPILE) $(CFLAGS) $< -o $@

--- a/makefile
+++ b/makefile
@@ -38,7 +38,8 @@ PATHA = build/artifacts/
 
 BUILD_PATHS = $(PATHB) $(PATHD) $(PATHO) $(PATHR) $(PATHA)
 
-EMBEDDB_OBJECTS = $(PATHO)embedDB.o $(PATHO)spline.o $(PATHO)radixspline.o $(PATHO)embedDBUtility.o $(PATHO)desktopFileInterface.o 
+EMBEDDB_OBJECTS = $(PATHO)embedDB.o $(PATHO)spline.o $(PATHO)radixspline.o $(PATHO)embedDBUtility.o
+EMBEDDB_FILE_INTERFACE = $(PATHO)desktopFileInterface.o
 
 QUERY_OBJECTS = $(PATHO)schema.o $(PATHO)advancedQueries.o
 
@@ -64,7 +65,15 @@ build: $(BUILD_PATHS) $(PATHB)desktopMain.$(TARGET_EXTENSION)
 	-./$(PATHB)desktopMain.$(TARGET_EXTENSION)
 	@echo "Finished EmbedDB Desktop Build"
 
-$(PATHB)desktopMain.$(TARGET_EXTENSION): $(EMBEDDB_OBJECTS) $(QUERY_OBJECTS) $(EMBEDDB_DESKTOP)
+$(PATHB)desktopMain.$(TARGET_EXTENSION): $(EMBEDDB_OBJECTS) $(QUERY_OBJECTS) $(EMBEDDB_DESKTOP) $(EMBEDDB_FILE_INTERFACE)
+	$(LINK) -o $@ $^ $(MATH)
+
+dist: $(BUILD_PATHS) $(PATHB)distributionMain.$(TARGET_EXTENSION)
+	@echo "Running EmbedDB Distribution Desktop Build File"
+	-./$(PATHB)distributionMain.$(TARGET_EXTENSION)
+	@echo "Finished EmbedDB Distribution Desktop Build"
+
+$(PATHB)distributionMain.$(TARGET_EXTENSION): $(PATHO)distribution.o $(EMBEDDB_DESKTOP) $(EMBEDDB_FILE_INTERFACE)
 	$(LINK) -o $@ $^ $(MATH)
 
 test: $(BUILD_PATHS) $(RESULTS)
@@ -75,12 +84,15 @@ $(PATHR)%.testpass: $(PATHB)%.$(TARGET_EXTENSION)
 	$(MKDIR) $(@D)
 	-./$< > $@ 2>&1
 
-$(PATHB)test%.$(TARGET_EXTENSION): $(PATHO)test%.o $(EMBEDDB_OBJECTS) $(QUERY_OBJECTS) $(PATHO)unity.o #$(PATHD)Test%.d
+$(PATHB)test%.$(TARGET_EXTENSION): $(PATHO)test%.o $(EMBEDDB_OBJECTS) $(QUERY_OBJECTS) $(EMBEDDB_FILE_INTERFACE) $(PATHO)unity.o #$(PATHD)Test%.d
 	$(MKDIR) $(@D)
 	$(LINK) -o $@ $^ $(MATH)
 
 $(PATHO)%.o:: $(PATHT)%.cpp
 	$(MKDIR) $(@D)
+	$(COMPILE) $(CFLAGS) $< -o $@
+
+$(PATHO)distribution.o:: $(PATH_DISTRIBUTION)embedDB.c
 	$(COMPILE) $(CFLAGS) $< -o $@
 
 $(PATHO)%.o:: $(PATHS)%.c

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,24 @@ build_flags =
     -lm
 extra_scripts = pre:scripts/create_build_folder.py
 
+[env:desktop-dist]
+platform = native
+test_build_src = true
+build_src_filter =
+    +<**/*.c>
+    +<**/*.cpp>
+    -<**/memboardMain.cpp>
+    -<**/megaMain.cpp>
+    -<**/dueMain.cpp>
+    -<embedDB/**>
+    -<query-interface/**>
+    -<spline/**>
+lib_ignore = Dataflash, Dataflash-File-Interface, Dataflash-Wrapper, Due, Mega, Memboard, SD-File-Interface, SD-Test, SD-Wrapper, SdFat, Serial-Wrapper, Unity-Desktop
+build_flags =
+    -DDIST
+    -lm
+extra_scripts = pre:scripts/create_build_folder.py
+
 [env:memboard]
 platform = atmelsam
 board = adafruit_feather_m0


### PR DESCRIPTION
### Description
- Add the ability to run the distribution version of EmbedDB on desktop platforms using both PlatformIO and our makefile
- Added GitHub action to run all benchmarks, example files, and unit tests on the distribution version of EmbedDB on both Windows and Linux.