### PR TITLE
Require Allocated Datafile Pages to be Divisible by the Erase Size in Pages

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ build_src_filter =
 lib_ignore = Dataflash, Dataflash-File-Interface, Dataflash-Wrapper, Distribution, Due, Mega, Memboard, SD-File-Interface, SD-Test, SD-Wrapper, SdFat, Serial-Wrapper, Unity-Desktop
 build_flags = 
     -lm
+    -DPRINT_ERRORS
 extra_scripts = pre:scripts/create_build_folder.py
 
 [env:desktop-dist]

--- a/src/embedDB/embedDB.c
+++ b/src/embedDB/embedDB.c
@@ -180,8 +180,22 @@ int8_t embedDBInit(embedDBState *state, size_t indexMaxError) {
         return -1;
     }
 
+    /* check the number of allocated pages is a multiple of the erase size */
+    if (state->numDataPages % state->eraseSizeInPages != 0) {
+#ifdef PRINT_ERRORS
+        printf("ERROR: The number of allocated data pages must be divisible by the erase size in pages.\n");
+#endif
+        return -1;
+    }
+
     state->recordSize = state->keySize + state->dataSize;
     if (EMBEDDB_USING_VDATA(state->parameters)) {
+        if (state->numVarPages % state->eraseSizeInPages != 0) {
+#ifdef PRINT_ERRORS
+            printf("ERROR: The number of allocated variable data pages must be divisible by the erase size in pages.\n");
+#endif
+            return -1;
+        }
         state->recordSize += 4;
     }
 
@@ -191,8 +205,15 @@ int8_t embedDBInit(embedDBState *state, size_t indexMaxError) {
 
     /* Header size depends on bitmap size: 6 + X bytes: 4 byte id, 2 for record count, X for bitmap. */
     state->headerSize = 6;
-    if (EMBEDDB_USING_INDEX(state->parameters))
+    if (EMBEDDB_USING_INDEX(state->parameters)) {
+        if (state->numIndexPages % state->eraseSizeInPages != 0) {
+#ifdef PRINT_ERRORS
+            printf("ERROR: The number of allocated index pages must be divisible by the erase size in pages.\n");
+#endif
+            return -1;
+        }
         state->headerSize += state->bitmapSize;
+    }
 
     if (EMBEDDB_USING_MAX_MIN(state->parameters))
         state->headerSize += state->keySize * 2 + state->dataSize * 2;

--- a/test/test_embedDB_data_recovery/test_embedDB_data_recovery.cpp
+++ b/test/test_embedDB_data_recovery/test_embedDB_data_recovery.cpp
@@ -84,7 +84,7 @@ void setupEmbedDB() {
     state->fileInterface = getFileInterface();
     state->dataFile = setupFile(DATA_FILE_PATH);
 
-    state->numDataPages = 93;
+    state->numDataPages = 92;
     state->eraseSizeInPages = 4;
     state->parameters = EMBEDDB_RESET_DATA;
     state->compareKey = int32Comparator;
@@ -108,7 +108,7 @@ void initalizeEmbedDBFromFile(void) {
     state->fileInterface = getFileInterface();
     state->dataFile = setupFile(DATA_FILE_PATH);
 
-    state->numDataPages = 93;
+    state->numDataPages = 92;
     state->eraseSizeInPages = 4;
     state->parameters = 0;
     state->compareKey = int32Comparator;
@@ -163,28 +163,28 @@ void embedDB_parameters_initializes_from_data_file_with_twenty_seven_pages_corre
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinKey, &state->minKey, sizeof(uint64_t), "EmbedDB minkey is not correctly identified after reload from data file.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(27, state->nextDataPageId, "EmbedDB nextDataPageId is not correctly identified after reload from data file.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->minDataPageId, "EmbedDB minDataPageId was not correctly identified.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(66, state->numAvailDataPages, "EmbedDB numAvailDataPages is not correctly initialized.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(65, state->numAvailDataPages, "EmbedDB numAvailDataPages is not correctly initialized.");
 }
 
 /* The setup function allocates 93 pages, so check to make sure it initalizes correctly when it is full */
-void embedDB_parameters_initializes_from_data_file_with_ninety_three_pages_correctly() {
-    insertRecordsLinearly(3456, 2548, 3907);
+void embedDB_parameters_initializes_from_data_file_with_ninety_two_pages_correctly() {
+    insertRecordsLinearly(3456, 2548, 3865);
     tearDown();
     initalizeEmbedDBFromFile();
     uint64_t expectedMinKey = 3457;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinKey, &state->minKey, sizeof(uint64_t), "EmbedDB minkey is not correctly identified after reload from data file.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(93, state->nextDataPageId, "EmbedDB nextDataPageId is not correctly identified after reload from data file.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(92, state->nextDataPageId, "EmbedDB nextDataPageId is not correctly identified after reload from data file.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->minDataPageId, "EmbedDB minDataPageId was not correctly identified.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->numAvailDataPages, "EmbedDB numAvailDataPages is not correctly initialized.");
 }
 
-void embedDB_parameters_initializes_from_data_file_with_ninety_four_pages_correctly() {
-    insertRecordsLinearly(1645, 2548, 3949);
+void embedDB_parameters_initializes_from_data_file_with_ninety_three_pages_correctly() {
+    insertRecordsLinearly(1645, 2548, 3907);
     tearDown();
     initalizeEmbedDBFromFile();
-    uint64_t expectedMinKey = 1688;
-    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinKey, &state->minKey, sizeof(uint64_t), "EmbedDB minkey is not correctly identified after reload from data file.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(94, state->nextDataPageId, "EmbedDB nextDataPageId is not correctly identified after reload from data file.");
+    uint32_t expectedMinKey = 1688;
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(expectedMinKey, state->minKey, "EmbedDB minkey is not correctly identified after reload from data file.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(93, state->nextDataPageId, "EmbedDB nextDataPageId is not correctly identified after reload from data file.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, state->minDataPageId, "EmbedDB minDataPageId was not correctly identified.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->numAvailDataPages, "EmbedDB numAvailDataPages is not correctly initialized.");
 }
@@ -193,10 +193,10 @@ void embedDB_parameters_initializes_correctly_from_data_file_with_four_hundred_s
     insertRecordsLinearly(2000, 11205, 17515);
     tearDown();
     initalizeEmbedDBFromFile();
-    uint64_t expectedMinKey = 15609;
-    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinKey, &state->minKey, sizeof(uint64_t), "EmbedDB minkey is not correctly identified after reload from data file.");
+    uint32_t expectedMinKey = 15651;
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(expectedMinKey, state->minKey, "EmbedDB minkey is not correctly identified after reload from data file.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(417, state->nextDataPageId, "EmbedDB nextDataPageId is not correctly identified after reload from data file.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(324, state->minDataPageId, "EmbedDB minDataPageId was not correctly identified.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(325, state->minDataPageId, "EmbedDB minDataPageId was not correctly identified.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->numAvailDataPages, "EmbedDB numAvailDataPages is not correctly initialized.");
 }
 
@@ -207,7 +207,7 @@ void embedDB_parameters_initializes_correctly_from_data_file_with_no_data() {
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinKey, &state->minKey, sizeof(uint64_t), "EmbedDB minkey is not correctly identified after reload from data file.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->nextDataPageId, "EmbedDB nextDataPageId is not correctly identified after reload from data file.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->minDataPageId, "EmbedDB minDataPageId was not correctly identified.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(93, state->numAvailDataPages, "EmbedDB numAvailDataPages is not ");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(92, state->numAvailDataPages, "EmbedDB numAvailDataPages is not ");
 }
 
 void embedDB_inserts_correctly_into_data_file_after_reload() {
@@ -248,14 +248,14 @@ void embedDB_correctly_gets_records_after_reload_with_wrapped_data() {
     embedDBFlush(state);
     tearDown();
     initalizeEmbedDBFromFile();
-    uint64_t expectedMinKey = 9871;
-    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinKey, &state->minKey, sizeof(uint64_t), "EmbedDB minkey is not the correct value after reloading.");
+    uint32_t expectedMinKey = 9913;
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(expectedMinKey, state->minKey, "EmbedDB minkey is not the correct value after reloading.");
     int8_t *recordBuffer = (int8_t *)malloc(state->dataSize);
-    int32_t key = 9871;
-    int64_t data = 9871;
+    int32_t key = 9913;
+    int64_t data = 9913;
     char message[100];
     /* Records inserted before reload */
-    for (int i = 0; i < 3888; i++) {
+    for (int i = 0; i < 3845; i++) {
         int8_t getResult = embedDBGet(state, &key, recordBuffer);
         snprintf(message, 100, "EmbedDB get encountered an error fetching the data for key %li.", key);
         TEST_ASSERT_EQUAL_INT8_MESSAGE(0, getResult, message);
@@ -281,8 +281,8 @@ void embedDB_queries_correctly_with_non_liner_data_after_reload() {
     insertRecordsParabolic(1000, 367, 4495);
     tearDown();
     initalizeEmbedDBFromFile();
-    uint64_t expectedMinKey = 174166;
-    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinKey, &state->minKey, sizeof(uint64_t), "EmbedDB minkey is not the correct value after reloading.");
+    uint32_t expectedMinKey = 199765;
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(expectedMinKey, state->minKey, "EmbedDB minkey is not the correct value after reloading.");
     int8_t *recordBuffer = (int8_t *)malloc(state->dataSize);
     int32_t key = 174166;
     int64_t data = 956;
@@ -303,8 +303,8 @@ void embedDB_queries_correctly_with_non_liner_data_after_reload() {
 int runUnityTests() {
     UNITY_BEGIN();
     RUN_TEST(embedDB_parameters_initializes_from_data_file_with_twenty_seven_pages_correctly);
+    RUN_TEST(embedDB_parameters_initializes_from_data_file_with_ninety_two_pages_correctly);
     RUN_TEST(embedDB_parameters_initializes_from_data_file_with_ninety_three_pages_correctly);
-    RUN_TEST(embedDB_parameters_initializes_from_data_file_with_ninety_four_pages_correctly);
     RUN_TEST(embedDB_parameters_initializes_correctly_from_data_file_with_four_hundred_seventeen_previous_page_inserts);
     RUN_TEST(embedDB_inserts_correctly_into_data_file_after_reload);
     RUN_TEST(embedDB_correctly_gets_records_after_reload_with_wrapped_data);

--- a/test/test_embedDB_storage/test_embedDB_storage.cpp
+++ b/test/test_embedDB_storage/test_embedDB_storage.cpp
@@ -1,0 +1,199 @@
+#ifdef DIST
+#include "embedDB.h"
+#else
+#include "embedDB/embedDB.h"
+#include "embedDBUtility.h"
+#endif
+
+#if defined(MEMBOARD)
+#include "memboardTestSetup.h"
+#endif
+
+#if defined(MEGA)
+#include "megaTestSetup.h"
+#endif
+
+#if defined(DUE)
+#include "dueTestSetup.h"
+#endif
+
+#ifdef ARDUINO
+#include "SDFileInterface.h"
+#define getFileInterface getSDInterface
+#define setupFile setupSDFile
+#define tearDownFile tearDownSDFile
+#define DATA_FILE_PATH "dataFile.bin"
+#define INDEX_FILE_PATH "indexFile.bin"
+#define VAR_DATA_FILE_PATH "varFile.bin"
+#else
+#include "desktopFileInterface.h"
+#define DATA_FILE_PATH "build/artifacts/dataFile.bin"
+#define INDEX_FILE_PATH "build/artifacts/indexFile.bin"
+#define VAR_DATA_FILE_PATH "build/artifacts/varFile.bin"
+#endif
+
+#include "unity.h"
+
+embedDBState *state;
+
+void setUp() {
+}
+
+void tearDown() {
+    free(state->buffer);
+    free(state->fileInterface);
+    free(state);
+}
+
+void embedDBInit_should_return_erorr_if_numDataPages_is_not_divisible_by_eraseSizeInPages() {
+    state = (embedDBState *)malloc(sizeof(embedDBState));
+    TEST_ASSERT_NOT_NULL_MESSAGE(state, "Unable to allocate embedDBState.");
+    state->keySize = 4;
+    state->dataSize = 8;
+    state->pageSize = 512;
+    state->bufferSizeInBlocks = 8;
+    state->numSplinePoints = 4;
+    state->buffer = malloc((size_t)state->bufferSizeInBlocks * state->pageSize);
+    TEST_ASSERT_NOT_NULL_MESSAGE(state->buffer, "Failed to allocate buffer for EmbedDB.");
+
+    /* configure EmbedDB storage */
+    state->fileInterface = getFileInterface();
+    state->dataFile = setupFile(DATA_FILE_PATH);
+
+    state->eraseSizeInPages = 4;
+    state->parameters = EMBEDDB_RESET_DATA;
+    state->compareKey = int32Comparator;
+    state->compareData = int64Comparator;
+
+    /* Check for off by one */
+    state->numDataPages = 407;
+    int8_t result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(-1, result, "embedDBInit should have failed as the allocated data pages are not divisible by the erase size in pages.");
+
+    /* Check for off by one */
+    state->numDataPages = 409;
+    result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(-1, result, "embedDBInit should have failed as the allocated data pages are not divisible by the erase size in pages.");
+
+    /* Check for successful init */
+    state->numDataPages = 408;
+    result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "embedDBInit should have failed as the allocated data pages are not divisible by the erase size in pages.");
+
+    /* Tear down successful init */
+    embedDBClose(state);
+    tearDownFile(state->dataFile);
+}
+
+void embedDBInit_should_return_erorr_if_numIndexPages_is_not_divisible_by_eraseSizeInPages() {
+    state = (embedDBState *)malloc(sizeof(embedDBState));
+    state->keySize = 4;
+    state->dataSize = 4;
+    state->pageSize = 512;
+    state->bufferSizeInBlocks = 4;
+    state->numSplinePoints = 2;
+    state->buffer = calloc(1, state->pageSize * state->bufferSizeInBlocks);
+    TEST_ASSERT_NOT_NULL_MESSAGE(state->buffer, "Failed to allocate buffer for EmbedDB.");
+
+    /* setup EmbedDB storage */
+    state->fileInterface = getFileInterface();
+    state->dataFile = setupFile(DATA_FILE_PATH);
+    state->indexFile = setupFile(INDEX_FILE_PATH);
+
+    state->numDataPages = 300;
+    state->eraseSizeInPages = 3;
+    state->bitmapSize = 1;
+    state->parameters = EMBEDDB_USE_INDEX | EMBEDDB_RESET_DATA;
+    state->inBitmap = inBitmapInt8;
+    state->updateBitmap = updateBitmapInt8;
+    state->buildBitmapFromRange = buildBitmapInt8FromRange;
+    state->compareKey = int32Comparator;
+    state->compareData = int32Comparator;
+
+    /* Check for off by one */
+    state->numIndexPages = 16;
+    int8_t result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(-1, result, "embedDBInit should have failed as the allocated index pages are not divisible by the erase size in pages.");
+
+    /* Check for off by one */
+    state->numIndexPages = 14;
+    result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(-1, result, "embedDBInit should have failed as the allocated index pages are not divisible by the erase size in pages.");
+
+    /* Check for off by one */
+    state->numIndexPages = 15;
+    result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "embedDBInit should have failed as the allocated index pages are not divisible by the erase size in pages.");
+
+    /* Tear down successful init */
+    embedDBClose(state);
+    tearDownFile(state->dataFile);
+    tearDownFile(state->indexFile);
+}
+
+void embedDBInit_should_return_erorr_if_numVarPages_is_not_divisible_by_eraseSizeInPages() {
+    state = (embedDBState *)malloc(sizeof(embedDBState));
+    state->keySize = 4;
+    state->dataSize = 4;
+    state->pageSize = 512;
+    state->bufferSizeInBlocks = 16;
+    state->numSplinePoints = 2;
+    state->buffer = calloc(1, state->pageSize * state->bufferSizeInBlocks);
+    TEST_ASSERT_NOT_NULL_MESSAGE(state->buffer, "Failed to allocate EmbedDB buffer.");
+
+    state->fileInterface = getFileInterface();
+    char dataPath[] = DATA_FILE_PATH, varPath[] = VAR_DATA_FILE_PATH;
+    state->dataFile = setupFile(dataPath);
+    state->varFile = setupFile(varPath);
+
+    state->numDataPages = 64;
+    state->eraseSizeInPages = 4;
+    state->parameters = EMBEDDB_USE_VDATA | EMBEDDB_RESET_DATA;
+    state->compareKey = int32Comparator;
+    state->compareData = int32Comparator;
+
+    /* Check for off by one error */
+    state->numVarPages = 33;
+    int8_t result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(-1, result, "embedDBInit should have failed as the allocated variable data pages are not divisible by the erase size in pages.");
+
+    /* Check for off by one error */
+    state->numVarPages = 31;
+    result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(-1, result, "embedDBInit should have failed as the allocated variable data pages are not divisible by the erase size in pages.");
+
+    /* Check correct init */
+    state->numVarPages = 32;
+    result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "embedDBInit should have failed as the allocated variable data pages are not divisible by the erase size in pages.");
+
+    embedDBClose(state);
+    tearDownFile(state->dataFile);
+    tearDownFile(state->varFile);
+}
+
+int runUnityTests() {
+    UNITY_BEGIN();
+    RUN_TEST(embedDBInit_should_return_erorr_if_numDataPages_is_not_divisible_by_eraseSizeInPages);
+    RUN_TEST(embedDBInit_should_return_erorr_if_numIndexPages_is_not_divisible_by_eraseSizeInPages);
+    RUN_TEST(embedDBInit_should_return_erorr_if_numVarPages_is_not_divisible_by_eraseSizeInPages);
+    return UNITY_END();
+}
+
+#ifdef ARDUINO
+
+void setup() {
+    delay(2000);
+    setupBoard();
+    runUnityTests();
+}
+
+void loop() {}
+
+#else
+
+int main() {
+    return runUnityTests();
+}
+
+#endif

--- a/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
+++ b/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
@@ -58,7 +58,7 @@
 #define setupFile setupSDFile
 #define tearDownFile tearDownSDFile
 #define DATA_FILE_PATH "dataFile.bin"
-#define INDEX_FILE_PATH "indexFile.bin"s
+#define INDEX_FILE_PATH "indexFile.bin"
 #define VAR_DATA_FILE_PATH "varFile.bin"
 #else
 #include "desktopFileInterface.h"
@@ -86,8 +86,8 @@ void setupEmbedDB() {
     state->dataFile = setupFile(dataPath);
     state->varFile = setupFile(varPath);
 
-    state->numDataPages = 65;
-    state->numVarPages = 75;
+    state->numDataPages = 64;
+    state->numVarPages = 76;
     state->eraseSizeInPages = 4;
     state->parameters = EMBEDDB_USE_VDATA | EMBEDDB_RESET_DATA;
     state->compareKey = int32Comparator;
@@ -111,8 +111,8 @@ void initalizeEmbedDBFromFile(void) {
     state->dataFile = setupFile(dataPath);
     state->varFile = setupFile(varPath);
 
-    state->numDataPages = 65;
-    state->numVarPages = 75;
+    state->numDataPages = 64;
+    state->numVarPages = 76;
     state->eraseSizeInPages = 4;
     state->parameters = EMBEDDB_USE_VDATA;
     state->compareKey = int32Comparator;
@@ -121,15 +121,18 @@ void initalizeEmbedDBFromFile(void) {
     TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "EmbedDB did not initialize correctly.");
 }
 
+void tearDownEmbedDB() {
+    embedDBClose(state);
+    tearDownFile(state->dataFile);
+    tearDownFile(state->varFile);
+}
+
 void setUp() {
     setupEmbedDB();
 }
 
 void tearDown() {
     free(state->buffer);
-    embedDBClose(state);
-    tearDownFile(state->dataFile);
-    tearDownFile(state->varFile);
     free(state->fileInterface);
     free(state);
 }
@@ -158,50 +161,59 @@ void embedDB_variable_data_page_numbers_are_correct() {
         memcpy(&pageNumber, buffer, sizeof(id_t));
         TEST_ASSERT_EQUAL_UINT32_MESSAGE(i, pageNumber, "EmbedDB variable data did not have the correct page number.");
     }
+    tearDownEmbedDB();
 }
 
 void embedDB_variable_data_reloads_with_no_data_correctly() {
+    tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_INT8_MESSAGE(8, state->variableDataHeaderSize, "EmbedDB variableDataHeaderSize did not have the correct value after initializing variable data from a file with no records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(8, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with no records.");
     uint64_t expectedMinVarRecordId = 0;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with no records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(75, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with no records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(76, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with no records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with no records.");
+    tearDownEmbedDB();
 }
 
 void embedDB_variable_data_reloads_with_one_page_of_data_correctly() {
     insertRecords(30, 100, 10);
+    tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(520, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
     uint64_t expectedMinVarRecordId = 0;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(74, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(75, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
+    tearDownEmbedDB();
 }
 
 void embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly() {
     insertRecords(337, 1648, 10);
+    tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(8200, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
     uint64_t expectedMinVarRecordId = 0;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(59, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(60, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(16, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
+    tearDownEmbedDB();
 }
 
-void embedDB_variable_data_reloads_with_one_hundred_six_pages_of_data_correctly() {
+void embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly() {
     insertRecords(2227, 100, 10);
+    tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(15880, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
-    uint64_t expectedMinVarRecordId = 773;
-    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(106, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(15368, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with 106 pages of records.");
+    uint64_t expectedMinVarRecordId = 761;
+    TEST_ASSERT_EQUAL_UINT64_MESSAGE(expectedMinVarRecordId, state->minVarRecordId, "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with 106 pages of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with 106 pages of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(106, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with 106 pages of records.");
+    tearDownEmbedDB();
 }
 
 void embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_correctly() {
@@ -209,6 +221,7 @@ void embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_cor
     int32_t data = 10;
     insertRecords(651, key, data);
     embedDBFlush(state);
+    tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
     int32_t recordData = 0;
@@ -236,6 +249,7 @@ void embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_cor
         data++;
         free(stream);
     }
+    tearDownEmbedDB();
 }
 
 void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly() {
@@ -243,6 +257,7 @@ void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_page
     int32_t data = 13467895;
     insertRecords(5187, key, data);
     embedDBFlush(state);
+    tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
     int32_t recordData = 0;
@@ -250,12 +265,12 @@ void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_page
     char variableDataBuffer[13];
     char message[120];
     embedDBVarDataStream *stream = NULL;
-    key = 9277;
-    data = 13470374;
+    key = 9319;
+    data = 13470416;
     /* Records inserted before reload */
-    for (int i = 0; i < 2708; i++) {
+    for (int i = 0; i < 2667; i++) {
         int8_t getResult = embedDBGetVar(state, &key, &recordData, &stream);
-        if (i > 1163) {
+        if (i > 1091) {
             snprintf(message, 120, "EmbedDB get encountered an error fetching the data for key %li.", key);
             TEST_ASSERT_EQUAL_INT8_MESSAGE(0, getResult, message);
             snprintf(message, 120, "EmbedDB get did not return correct data for a record inserted before reloading (key %li).", key);
@@ -278,6 +293,7 @@ void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_page
         key++;
         data++;
     }
+    tearDownEmbedDB();
 }
 
 int runUnityTests() {
@@ -286,7 +302,7 @@ int runUnityTests() {
     RUN_TEST(embedDB_variable_data_reloads_with_no_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_with_one_page_of_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly);
-    RUN_TEST(embedDB_variable_data_reloads_with_one_hundred_six_pages_of_data_correctly);
+    RUN_TEST(embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly);
     return UNITY_END();

--- a/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
+++ b/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
@@ -210,7 +210,7 @@ void embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly() {
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(15368, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with 106 pages of records.");
     uint64_t expectedMinVarRecordId = 761;
-    TEST_ASSERT_EQUAL_UINT64_MESSAGE(expectedMinVarRecordId, state->minVarRecordId, "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with 106 pages of records.");
+    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with 106 pages of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with 106 pages of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(106, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with 106 pages of records.");
     tearDownEmbedDB();

--- a/test/test_var_data_buffered_read/test_var_data_buffered_read.cpp
+++ b/test/test_var_data_buffered_read/test_var_data_buffered_read.cpp
@@ -460,7 +460,7 @@ embedDBState *init_state() {
     TEST_ASSERT_NOT_NULL_MESSAGE(state->buffer, "Failed to allocate EmbedDB buffer.");
 
     // address level parameters
-    state->numDataPages = 30;
+    state->numDataPages = 32;
     state->numIndexPages = 8;
     state->numVarPages = 12;
     state->eraseSizeInPages = 4;


### PR DESCRIPTION
### Description
- Currently, there is no check if the number of pages allocated to a data file is divisible by the erase size in pages.
- This does not matter on the SD card, but it does matter if the hardware you are using for storage can only be erased on block boundaries.