### PR TITLE
Fix EmbedDB Example Failing Due to Page Allocation Restrictions

### DIFF
--- a/src/benchmarks/queryInterfaceBenchmark.h
+++ b/src/benchmarks/queryInterfaceBenchmark.h
@@ -151,7 +151,11 @@ int advancedQueryExample() {
     stateUWA->inBitmap = inBitmapInt16;
     stateUWA->updateBitmap = updateBitmapInt16;
     stateUWA->buildBitmapFromRange = buildBitmapInt16FromRange;
-    embedDBInit(stateUWA, 1);
+    int8_t initResult = embedDBInit(stateUWA, 1);
+    if (initResult != 0) {
+        printf("There was an error setting up the state of the UWA dataset.");
+        return -1;
+    }
 
     int8_t colSizes[] = {4, 4, 4, 4};
     int8_t colSignedness[] = {embedDB_COLUMN_UNSIGNED, embedDB_COLUMN_SIGNED, embedDB_COLUMN_SIGNED, embedDB_COLUMN_SIGNED};
@@ -316,7 +320,11 @@ int advancedQueryExample() {
     stateSEA->inBitmap = inBitmapInt16;
     stateSEA->updateBitmap = updateBitmapInt16;
     stateSEA->buildBitmapFromRange = buildBitmapInt16FromRange;
-    embedDBInit(stateSEA, 1);
+    initResult = embedDBInit(stateSEA, 1);
+    if (initResult != 0) {
+        printf("There was an error setting up the state of the SEA dataset.");
+        return -1;
+    }
 
     // Insert records
     insertData(stateSEA, "data/sea100K.bin");

--- a/src/benchmarks/queryInterfaceBenchmark.h
+++ b/src/benchmarks/queryInterfaceBenchmark.h
@@ -400,6 +400,7 @@ int advancedQueryExample() {
     free(stateSEA->buffer);
     free(stateSEA);
     embedDBFreeSchema(&baseSchema);
+
     return 0;
 }
 

--- a/src/benchmarks/sequentialDataBenchmark.h
+++ b/src/benchmarks/sequentialDataBenchmark.h
@@ -93,7 +93,7 @@
 /**
  * Runs all tests and collects benchmarks
  */
-void runalltests_embedDB() {
+int runalltests_embedDB() {
     printf("\n EmbedDB Example: \n");
     int8_t M = 4;
     int32_t numRecords = 1000;     // default values
@@ -247,7 +247,7 @@ void runalltests_embedDB() {
         /* Initialize embedDB structure with parameters */
         if (embedDBInit(state, splineMaxError) != 0) {
             printf("Initialization error.\n");
-            return;
+            return -1;
         }
 
         embedDBPrintInit(state);

--- a/src/benchmarks/sequentialDataBenchmark.h
+++ b/src/benchmarks/sequentialDataBenchmark.h
@@ -636,6 +636,7 @@ int runalltests_embedDB() {
         }
         printf("\t%lu\n", sum / r);
     }
+    return 0;
 }
 
 #endif

--- a/src/benchmarks/variableDataBenchmark.h
+++ b/src/benchmarks/variableDataBenchmark.h
@@ -943,6 +943,8 @@ int test_vardata() {
         }
         printf("\t%lu\n", sum / r);
     }
+
+    return 0;
 }
 
 uint32_t randomData(void **data, uint32_t sizeLowerBound, uint32_t sizeUpperBound) {

--- a/src/benchmarks/variableDataBenchmark.h
+++ b/src/benchmarks/variableDataBenchmark.h
@@ -121,7 +121,7 @@ void retrieveImageData(embedDBState *state, embedDBVarDataStream *varStream, int
 uint8_t dataEquals(embedDBState *state, embedDBVarDataStream *varStream, Node *node);
 void randomVarData(uint32_t chance, uint32_t sizeLowerBound, uint32_t sizeUpperBound, uint8_t *usingVarData, uint32_t *length, void **varData);
 
-void test_vardata() {
+int test_vardata() {
     printf("\nSTARTING EmbedDB VARIABLE DATA TESTS.\n");
 
     // Two extra bufferes required for variable data
@@ -267,7 +267,7 @@ void test_vardata() {
 
         if (embedDBInit(state, splineMaxError) != 0) {
             printf("Initialization error.\n");
-            return;
+            return -1;
         } else {
             printf("Initialization success.\n");
             embedDBPrintInit(state);

--- a/src/desktopMain.c
+++ b/src/desktopMain.c
@@ -19,15 +19,15 @@
 #include "benchmarks/queryInterfaceBenchmark.h"
 #endif
 
-void main() {
+int main() {
 #if WHICH_PROGRAM == 0
-    embedDBExample();
+    return embedDBExample();
 #elif WHICH_PROGRAM == 1
-    runalltests_embedDB();
+    return runalltests_embedDB();
 #elif WHICH_PROGRAM == 2
-    test_vardata();
+    return test_vardata();
 #elif WHICH_PROGRAM == 3
-    advancedQueryExample();
+    return advancedQueryExample();
 #endif
 }
 

--- a/src/embedDBExample.h
+++ b/src/embedDBExample.h
@@ -301,7 +301,7 @@ embedDBState* init_state() {
     // address storage characteristics
     state->numDataPages = 1000;
     state->numIndexPages = 48;
-    state->numVarPages = 75;
+    state->numVarPages = 76;
     state->eraseSizeInPages = 4;
 
     if (STORAGE_TYPE == 1) {

--- a/src/embedDBExample.h
+++ b/src/embedDBExample.h
@@ -277,7 +277,7 @@ embedDBState* init_state() {
     // ensure successful malloc
     if (state == NULL) {
         printf("Unable to allocate state. Exiting\n");
-        exit(0);
+        exit(-1);
     }
     /* configure EmbedDB state variables */
     // for fixed-length records
@@ -291,7 +291,7 @@ embedDBState* init_state() {
     // ensure successful malloc
     if (state->buffer == NULL) {
         printf("Unable to allocate buffer. Exciting\n");
-        exit(0);
+        exit(-1);
     }
 
     // for learned indexing and bitmap
@@ -328,7 +328,7 @@ embedDBState* init_state() {
     size_t splineMaxError = 1;
     if (embedDBInit(state, splineMaxError) != 0) {
         printf("Initialization error");
-        exit(0);
+        exit(-1);
     }
 
     embedDBResetStats(state);


### PR DESCRIPTION
### Description
- The EmbedDB example was currently not working due to changes in #112, but the CI was not catching this because the program was exiting with status code 0.
- Now benchmarks and examples have been updated to return a non-zero value if they fail to init, which will be caught by the CI pipeline.