### PR TITLE
Flush Methods No Longer Write When Buffer has No Data

### DIFF
--- a/src/embedDB/embedDB.c
+++ b/src/embedDB/embedDB.c
@@ -84,7 +84,6 @@ int8_t embedDBSetupVarDataStream(embedDBState *state, void *key, embedDBVarDataS
 uint32_t cleanSpline(embedDBState *state, void *key);
 void readToWriteBuf(embedDBState *state);
 void readToWriteBufVar(embedDBState *state);
-void embedDBFlushVar(embedDBState *state);
 
 void printBitmap(char *bm) {
     for (int8_t i = 0; i <= 7; i++) {
@@ -1656,12 +1655,25 @@ void embedDBCloseIterator(embedDBIterator *it) {
 }
 
 /**
- * @brief   Flushes variable write buffer to storage and updates variable record pointer accordingly.
- * @param   state   algorithm state structure
+ * @brief	Flushes output buffer.
+ * @param	state	algorithm state structure
+ * @returns 0 if successul and a non-zero value otherwise
  */
-void embedDBFlushVar(embedDBState *state) {
+int8_t embedDBFlushVar(embedDBState *state) {
+    /* Check if we actually have any variable data in the buffer */
+    if (state->currentVarLoc % state->pageSize == state->variableDataHeaderSize) {
+        return 0;
+    }
+
     // only flush variable buffer
-    writeVariablePage(state, (int8_t *)state->buffer + EMBEDDB_VAR_WRITE_BUFFER(state->parameters) * state->pageSize);
+    id_t writeResult = writeVariablePage(state, (int8_t *)state->buffer + EMBEDDB_VAR_WRITE_BUFFER(state->parameters) * state->pageSize);
+    if (writeResult == -1) {
+#ifdef PRINT_ERRORS
+        printf("Failed to write variable data page during embedDBFlushVar.");
+#endif
+        return -1;
+    }
+
     state->fileInterface->flush(state->varFile);
     // init new buffer
     initBufferPage(state, EMBEDDB_VAR_WRITE_BUFFER(state->parameters));
@@ -1669,15 +1681,28 @@ void embedDBFlushVar(embedDBState *state) {
     int temp = state->pageSize - (state->currentVarLoc % state->pageSize);
     // create new offset
     state->currentVarLoc += temp + state->variableDataHeaderSize;
+    return 0;
 }
 
 /**
  * @brief	Flushes output buffer.
  * @param	state	algorithm state structure
+ * @returns 0 if successul and a non-zero value otherwise
  */
 int8_t embedDBFlush(embedDBState *state) {
     // As the first buffer is the data write buffer, no address change is required
-    id_t pageNum = writePage(state, (int8_t *)state->buffer + EMBEDDB_DATA_WRITE_BUFFER * state->pageSize);
+    int8_t *buffer = (int8_t *)state->buffer + EMBEDDB_DATA_WRITE_BUFFER * state->pageSize;
+    if (EMBEDDB_GET_COUNT(buffer) < 1)
+        return 0;
+
+    id_t pageNum = writePage(state, buffer);
+    if (pageNum == -1) {
+#ifdef PRINT_ERRORS
+        printf("Failed to write page during embedDBFlush.");
+#endif
+        return -1;
+    }
+
     state->fileInterface->flush(state->dataFile);
 
     indexPage(state, pageNum);
@@ -1691,7 +1716,14 @@ int8_t embedDBFlush(embedDBState *state) {
         void *bm = EMBEDDB_GET_BITMAP(state->buffer);
         memcpy((void *)((int8_t *)buf + EMBEDDB_IDX_HEADER_SIZE + state->bitmapSize * idxcount), bm, state->bitmapSize);
 
-        writeIndexPage(state, buf);
+        id_t writeResult = writeIndexPage(state, buf);
+        if (writeResult == -1) {
+#ifdef PRINT_ERRORS
+            printf("Failed to write index page during embedDBFlush.");
+#endif
+            return -1;
+        }
+
         state->fileInterface->flush(state->indexFile);
 
         /* Reinitialize buffer */
@@ -1704,7 +1736,14 @@ int8_t embedDBFlush(embedDBState *state) {
     // Flush var data page
     if (EMBEDDB_USING_VDATA(state->parameters)) {
         // send write buffer pointer to write variable page
-        writeVariablePage(state, (int8_t *)state->buffer + EMBEDDB_VAR_WRITE_BUFFER(state->parameters) * state->pageSize);
+        id_t writeResult = writeVariablePage(state, (int8_t *)state->buffer + EMBEDDB_VAR_WRITE_BUFFER(state->parameters) * state->pageSize);
+        if (writeResult == -1) {
+#ifdef PRINT_ERRORS
+            printf("Failed to write variable data page during embedDBFlush.");
+#endif
+            return -1;
+        }
+
         state->fileInterface->flush(state->varFile);
         // init new buffer
         initBufferPage(state, EMBEDDB_VAR_WRITE_BUFFER(state->parameters));

--- a/src/embedDB/embedDB.h
+++ b/src/embedDB/embedDB.h
@@ -384,9 +384,17 @@ uint32_t embedDBVarDataStreamRead(embedDBState *state, embedDBVarDataStream *str
 
 /**
  * @brief	Flushes output buffer.
- * @param	state	embedDB algorithm state structure
+ * @param	state	algorithm state structure
+ * @returns 0 if successul and a non-zero value otherwise
  */
 int8_t embedDBFlush(embedDBState *state);
+
+/**
+ * @brief	Flushes output buffer.
+ * @param	state	algorithm state structure
+ * @returns 0 if successul and a non-zero value otherwise
+ */
+int8_t embedDBFlushVar(embedDBState *state);
 
 /**
  * @brief	Reads given page from storage.

--- a/test/test_buffered_read/test_buffered_read.cpp
+++ b/test/test_buffered_read/test_buffered_read.cpp
@@ -219,17 +219,14 @@ void embedDBGet_should_return_no_data_when_requested_key_greater_than_max_buffer
 }
 
 void embedDBGet_should_return_not_found_when_key_is_less_then_min_key(void) {
-    /* flush database so nextDataPageId > 0*/
-    embedDBFlush(state);
-
     /* insert some records */
-    uint32_t numInserts = 8;
-    for (uint32_t i = 1; i <= numInserts; ++i) {
+    uint32_t numInserts = 154;
+    for (uint32_t i = 100; i <= numInserts; ++i) {
         insertStaticRecord(state, i, (i + 100));
     }
 
     /* query for key lower then the min key in the database */
-    uint32_t key = 0;
+    uint32_t key = 99;
     uint32_t actualData[] = {0, 0, 0};
     int8_t embedDBGetResult = embedDBGet(state, &key, actualData);
 
@@ -264,7 +261,7 @@ int insertStaticRecord(embedDBState* state, uint32_t key, uint32_t data) {
     // set dataPtr[0] to data
     ((uint32_t*)dataPtr)[0] = data;
     // insert into buffer, save result
-    char result = embedDBPut(state, (void*)&key, (void*)dataPtr);
+    int8_t result = embedDBPut(state, (void*)&key, (void*)dataPtr);
     // free dataPtr
     free(dataPtr);
     // return based on success

--- a/test/test_embedDB/test_embedDB.cpp
+++ b/test/test_embedDB/test_embedDB.cpp
@@ -239,6 +239,17 @@ void iteratorReturnsCorrectRecords(void) {
     embedDBCloseIterator(&it);
 }
 
+void embedDBFlush_does_not_write_when_nothing_in_buffer() {
+    /* Check that flush should not write page out when there are no recors in write buffer*/
+    int8_t flushResult = embedDBFlush(state);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(0, flushResult, "embedDBFlush should have returned successful.");
+
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(UINT32_MAX, state->minKey, "EmbedDB minKey should not change when empty page flushed.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->nextDataPageId, "embedDBFlush should not change nextDataPageId when no records in buffer.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->minDataPageId, "embedDBFlush should not change minDataPageId when no records in buffer.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1000, state->numAvailDataPages, "embedDBFlush should not change numAvailDataPages when no records in buffer.");
+}
+
 int runUnityTests(void) {
     UNITY_BEGIN();
     RUN_TEST(embedDB_initial_configuration_is_correct);
@@ -247,6 +258,7 @@ int runUnityTests(void) {
     RUN_TEST(embedDB_put_inserts_one_page_of_records_correctly);
     RUN_TEST(embedDB_put_inserts_one_more_than_one_page_of_records_correctly);
     RUN_TEST(iteratorReturnsCorrectRecords);
+    RUN_TEST(embedDBFlush_does_not_write_when_nothing_in_buffer);
     return UNITY_END();
 }
 

--- a/test/test_embedDB_var_data/test_embedDB_var_data.cpp
+++ b/test/test_embedDB_var_data/test_embedDB_var_data.cpp
@@ -244,6 +244,18 @@ void test_insert_rest() {
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, insertRecords(numRecords - inserted), "Error while inserting records");
 }
 
+void embedDBFlushVar_should_not_write_when_no_data_in_buffer() {
+    initState(8);
+    embedDBInit(state, 0);
+    embedDBFlushVar(state);
+
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(8, state->currentVarLoc, "embedDBFlushVar should not change currentVarLoc when flushing an empty variable data page.");
+    uint64_t expectedMinVarRecordId = 0;
+    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "embedDBFlushVar should not change expectedMinVarRecordId when flushing an empty variable data page.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1000, state->numAvailVarPages, "embedDBFlushVar should not change numAvailVarPages when flushing an empty variable data page.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->nextVarPageId, "embedDBFlushVar should not change nextVarPageId when flushing an empty variable data page.");
+}
+
 int runUnityTests() {
     UNITY_BEGIN();
 
@@ -269,6 +281,8 @@ int runUnityTests() {
         // Clean up state
         resetState();
     }
+
+    RUN_TEST(embedDBFlushVar_should_not_write_when_no_data_in_buffer);
 
     return UNITY_END();
 }


### PR DESCRIPTION
### Description
- Refactored flush methods to skip write when the buffer has no data.