### PR TITLE
Add Record-Level Consistency and Update Recovery Algorithm for Variable Data

### DIFF
--- a/src/embedDB/embedDB.c
+++ b/src/embedDB/embedDB.c
@@ -888,15 +888,16 @@ int8_t embedDBInitVarDataFromFile(embedDBState *state) {
         int8_t readResult = readPage(state, state->minDataPageId % state->numDataPages);
         if (readResult != 0) {
 #ifdef PRINT_ERRORS
-            printf("Error: Read page in data file!\n");
+            printf("Error reading page in data file when recovering variable data. \n");
 #endif
             return -1;
         }
 
         /* Get smallest key from page and put it into the minVarRecordId */
+        uint64_t minKey = 0;
         void *dataBuffer = (int8_t *)state->buffer + state->pageSize * EMBEDDB_DATA_READ_BUFFER;
-        memcpy(&state->minVarRecordId, embedDBGetMinKey(state, buffer), state->keySize);
-
+        memcpy(&minKey, embedDBGetMinKey(state, dataBuffer), state->keySize);
+        state->minVarRecordId = minKey;
     } else {
         /* We lose some records, but know for sure we have all records larger than this*/
         memcpy(&(state->minVarRecordId), (int8_t *)buffer + sizeof(id_t), state->keySize);

--- a/src/embedDB/embedDB.c
+++ b/src/embedDB/embedDB.c
@@ -190,7 +190,7 @@ int8_t embedDBInit(embedDBState *state, size_t indexMaxError) {
         return -1;
     }
 
-    if (state->numDataPages < (EMBEDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters) ? 4 : 2) * state->eraseSizeInPages) {
+    if (state->numDataPages < (EMBEDDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters) ? 4 : 2) * state->eraseSizeInPages) {
 #ifdef PRINT_ERRORS
         printf("ERROR: The minimum number of data pages is twice the eraseSizeInPages or 4 times the eraseSizeInPages if using record-level consistency.\n");
 #endif
@@ -323,7 +323,7 @@ int8_t embedDBInitData(embedDBState *state) {
         return -1;
     }
 
-    if (EMBEDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters)) {
+    if (EMBEDDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters)) {
         state->numAvailDataPages -= (state->eraseSizeInPages * 2);
         state->nextRLCPhysicalPageLocation = state->eraseSizeInPages;
         state->rlcPhysicalStartingPage = state->eraseSizeInPages;
@@ -334,7 +334,7 @@ int8_t embedDBInitData(embedDBState *state) {
     if (!EMBEDDB_RESETING_DATA(state->parameters)) {
         openStatus = state->fileInterface->open(state->dataFile, EMBEDDB_FILE_MODE_R_PLUS_B);
         if (openStatus) {
-            if (EMBEDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters)) {
+            if (EMBEDDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters)) {
                 return embedDBInitDataFromFileWithRecordLevelConsistency(state);
             } else {
                 return embedDBInitDataFromFile(state);
@@ -1094,7 +1094,7 @@ int8_t embedDBPut(embedDBState *state, void *key, void *data) {
     }
 
     /* If using record level consistency, we need to immediately write the updated page to storage */
-    if (EMBEDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters)) {
+    if (EMBEDDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters)) {
         /* Need to move record level consistency pointers if on a block boundary */
         if (wrotePage && state->nextDataPageId % state->eraseSizeInPages == 0) {
             /* move record-level consistency blocks */
@@ -1257,6 +1257,11 @@ int8_t embedDBPutVar(embedDBState *state, void *key, void *data, void *variableD
             state->currentVarLoc += state->variableDataHeaderSize;
         }
     }
+
+    if (EMBEDDB_USING_RECORD_LEVEL_CONSISTENCY(state->parameters)) {
+        embedDBFlushVar(state);
+    }
+
     return 0;
 }
 

--- a/src/embedDB/embedDB.c
+++ b/src/embedDB/embedDB.c
@@ -898,7 +898,7 @@ int8_t embedDBInitVarDataFromFile(embedDBState *state) {
             dataBuffer = (int8_t *)state->buffer + state->pageSize * EMBEDDB_DATA_WRITE_BUFFER;
         } else {
             /* read page with smallest data we still have */
-            void *dataBuffer = (int8_t *)state->buffer + state->pageSize * EMBEDDB_DATA_READ_BUFFER;
+            dataBuffer = (int8_t *)state->buffer + state->pageSize * EMBEDDB_DATA_READ_BUFFER;
             readResult = readPage(state, state->minDataPageId % state->numDataPages);
             if (readResult != 0) {
 #ifdef PRINT_ERRORS

--- a/src/embedDB/embedDB.h
+++ b/src/embedDB/embedDB.h
@@ -66,7 +66,7 @@ typedef uint16_t count_t;
 #define EMBEDDB_USING_SUM(x) ((x & EMBEDDB_USE_SUM) > 0 ? 1 : 0)
 #define EMBEDDB_USING_BMAP(x) ((x & EMBEDDB_USE_BMAP) > 0 ? 1 : 0)
 #define EMBEDDB_USING_VDATA(x) ((x & EMBEDDB_USE_VDATA) > 0 ? 1 : 0)
-#define EMBEDB_USING_RECORD_LEVEL_CONSISTENCY(x) ((x & EMBEDDB_RECORD_LEVEL_CONSISTENCY) > 0 ? 1 : 0)
+#define EMBEDDB_USING_RECORD_LEVEL_CONSISTENCY(x) ((x & EMBEDDB_RECORD_LEVEL_CONSISTENCY) > 0 ? 1 : 0)
 #define EMBEDDB_RESETING_DATA(x) ((x & EMBEDDB_RESET_DATA) > 0 ? 1 : 0)
 
 /* Offsets with header */

--- a/src/spline/spline.c
+++ b/src/spline/spline.c
@@ -115,7 +115,6 @@ void splineAdd(spline *spl, void *key, uint32_t page) {
         memcpy(((int8_t *)spl->upper + spl->keySize), &upperPage, sizeof(uint32_t));
         memcpy(spl->lastKey, key, spl->keySize);
         spl->lastLoc = page;
-        return;
     }
 
     /* Skip duplicates */
@@ -123,7 +122,7 @@ void splineAdd(spline *spl, void *key, uint32_t page) {
     memcpy(&keyVal, key, spl->keySize);
     memcpy(&lastKeyVal, spl->lastKey, spl->keySize);
 
-    if (keyVal <= lastKeyVal)
+    if (keyVal <= lastKeyVal && spl->numAddCalls != 2)
         return;
 
     /* Last point added to spline, check if previous point is temporary - overwrite previous point if temporary */

--- a/test/test_embedDB_var_data/test_embedDB_var_data.cpp
+++ b/test/test_embedDB_var_data/test_embedDB_var_data.cpp
@@ -250,7 +250,7 @@ void embedDBFlushVar_should_not_write_when_no_data_in_buffer() {
     embedDBFlushVar(state);
 
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(8, state->currentVarLoc, "embedDBFlushVar should not change currentVarLoc when flushing an empty variable data page.");
-    uint64_t expectedMinVarRecordId = 0;
+    uint64_t expectedMinVarRecordId = UINT64_MAX;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "embedDBFlushVar should not change expectedMinVarRecordId when flushing an empty variable data page.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(1000, state->numAvailVarPages, "embedDBFlushVar should not change numAvailVarPages when flushing an empty variable data page.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->nextVarPageId, "embedDBFlushVar should not change nextVarPageId when flushing an empty variable data page.");

--- a/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
+++ b/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
@@ -198,8 +198,7 @@ void embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly() {
     tearDown();
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(8200, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
-    uint64_t expectedMinVarRecordId = 0;
-    TEST_ASSERT_EQUAL_UINT64_MESSAGE(expectedMinVarRecordId, state->minVarRecordId, "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
+    uint64_t expectedMinVarRecordId = 1649;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(60, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(16, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
@@ -212,9 +211,9 @@ void embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly() {
     tearDown();
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(15368, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with 106 pages of records.");
-    uint64_t expectedMinVarRecordId = 761;
-    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with 106 pages of records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with 106 pages of records.");
+    uint64_t expectedMinVarRecordId = 803;
+    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint32_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with 106 pages of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(2, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with 106 pages of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(106, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with 106 pages of records.");
     tearDownEmbedDB();
 }
@@ -303,9 +302,9 @@ int runUnityTests() {
     UNITY_BEGIN();
     // RUN_TEST(embedDB_variable_data_page_numbers_are_correct);
     // RUN_TEST(embedDB_variable_data_reloads_with_no_data_correctly);
-    RUN_TEST(embedDB_variable_data_reloads_with_one_page_of_data_correctly);
+    // RUN_TEST(embedDB_variable_data_reloads_with_one_page_of_data_correctly);
     // RUN_TEST(embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly);
-    // RUN_TEST(embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly);
+    RUN_TEST(embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly);
     // RUN_TEST(embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_correctly);
     // RUN_TEST(embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly);
     return UNITY_END();

--- a/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
+++ b/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
@@ -178,18 +178,34 @@ void embedDB_variable_data_reloads_with_no_data_correctly() {
     tearDownEmbedDB();
 }
 
-void embedDB_variable_data_reloads_with_one_page_of_data_correctly() {
+void embedDB_variable_data_reloads_correctly_when_variable_records_are_written_but_no_data_records_are_written() {
     insertRecords(30, 100, 10);
     tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(520, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
-    uint64_t expectedMinVarRecordId = 0;
-    TEST_ASSERT_EQUAL_UINT64_MESSAGE(expectedMinVarRecordId, state->minVarRecordId, "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(8, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
+    uint64_t expectedMinVarRecordId = UINT64_MAX;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(75, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(76, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
     tearDownEmbedDB();
+}
+
+void embedDB_variable_data_reloads_with_one_page_of_data_correctly() {
+    /* Insert records into state */
+    insertRecords(43, 100, 10);
+
+    /* Tear down this wall - Some American Politician */
+    tearDownEmbedDB();
+    tearDown();
+    initalizeEmbedDBFromFile();
+
+    /* Check that the state was setup correctly */
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1032, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
+    uint32_t expectedMinVarRecordId = 101;
+    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint32_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(74, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(2, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
 }
 
 void embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly() {
@@ -255,6 +271,7 @@ void embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_cor
 }
 
 void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly() {
+    /* Insert records and restart state */
     int32_t key = 6798;
     int32_t data = 13467895;
     insertRecords(5187, key, data);
@@ -262,6 +279,15 @@ void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_page
     tearDownEmbedDB();
     tearDown();
     initalizeEmbedDBFromFile();
+
+    /* Check that the state was setup correctly */
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(9736, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
+    uint32_t expectedMinVarRecordId = 10441;
+    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint32_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(247, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
+
+    /* Query records */
     int32_t recordData = 0;
     char variableData[13] = "Hello World!";
     char variableDataBuffer[13];
@@ -272,7 +298,7 @@ void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_page
     /* Records inserted before reload */
     for (int i = 0; i < 2499; i++) {
         int8_t getResult = embedDBGetVar(state, &key, &recordData, &stream);
-        if (i > 923) {
+        if (i > 953) {
             snprintf(message, 120, "EmbedDB get encountered an error fetching the data for key %li.", key);
             TEST_ASSERT_EQUAL_INT8_MESSAGE(0, getResult, message);
             snprintf(message, 120, "EmbedDB get did not return correct data for a record inserted before reloading (key %li).", key);
@@ -300,13 +326,14 @@ void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_page
 
 int runUnityTests() {
     UNITY_BEGIN();
-    // RUN_TEST(embedDB_variable_data_page_numbers_are_correct);
-    // RUN_TEST(embedDB_variable_data_reloads_with_no_data_correctly);
-    // RUN_TEST(embedDB_variable_data_reloads_with_one_page_of_data_correctly);
-    // RUN_TEST(embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly);
+    RUN_TEST(embedDB_variable_data_page_numbers_are_correct);
+    RUN_TEST(embedDB_variable_data_reloads_with_no_data_correctly);
+    RUN_TEST(embedDB_variable_data_reloads_correctly_when_variable_records_are_written_but_no_data_records_are_written);
+    RUN_TEST(embedDB_variable_data_reloads_with_one_page_of_data_correctly);
+    RUN_TEST(embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly);
-    // RUN_TEST(embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_correctly);
-    // RUN_TEST(embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly);
+    RUN_TEST(embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_correctly);
+    RUN_TEST(embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly);
     return UNITY_END();
 }
 

--- a/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
+++ b/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
@@ -171,7 +171,7 @@ void embedDB_variable_data_reloads_with_no_data_correctly() {
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_INT8_MESSAGE(8, state->variableDataHeaderSize, "EmbedDB variableDataHeaderSize did not have the correct value after initializing variable data from a file with no records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(8, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with no records.");
-    uint64_t expectedMinVarRecordId = 0;
+    uint64_t expectedMinVarRecordId = UINT64_MAX;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with no records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(76, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with no records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with no records.");
@@ -185,6 +185,7 @@ void embedDB_variable_data_reloads_with_one_page_of_data_correctly() {
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(520, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
     uint64_t expectedMinVarRecordId = 0;
+    TEST_ASSERT_EQUAL_UINT64_MESSAGE(expectedMinVarRecordId, state->minVarRecordId, "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(75, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
@@ -198,6 +199,7 @@ void embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly() {
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(8200, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with one page of records.");
     uint64_t expectedMinVarRecordId = 0;
+    TEST_ASSERT_EQUAL_UINT64_MESSAGE(expectedMinVarRecordId, state->minVarRecordId, "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint64_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(60, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with one page of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(16, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with one page of records.");
@@ -302,10 +304,10 @@ int runUnityTests() {
     // RUN_TEST(embedDB_variable_data_page_numbers_are_correct);
     // RUN_TEST(embedDB_variable_data_reloads_with_no_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_with_one_page_of_data_correctly);
-    RUN_TEST(embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly);
-    RUN_TEST(embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly);
-    RUN_TEST(embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_correctly);
-    RUN_TEST(embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly);
+    // RUN_TEST(embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly);
+    // RUN_TEST(embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly);
+    // RUN_TEST(embedDB_variable_data_reloads_and_queries_with_thirty_one_pages_of_data_correctly);
+    // RUN_TEST(embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_pages_of_data_correctly);
     return UNITY_END();
 }
 

--- a/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
+++ b/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
@@ -299,8 +299,8 @@ void embedDB_variable_data_reloads_and_queries_with_two_hundred_forty_seven_page
 
 int runUnityTests() {
     UNITY_BEGIN();
-    RUN_TEST(embedDB_variable_data_page_numbers_are_correct);
-    RUN_TEST(embedDB_variable_data_reloads_with_no_data_correctly);
+    // RUN_TEST(embedDB_variable_data_page_numbers_are_correct);
+    // RUN_TEST(embedDB_variable_data_reloads_with_no_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_with_one_page_of_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_with_sixteen_pages_of_data_correctly);
     RUN_TEST(embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly);

--- a/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
+++ b/test/test_embedDB_var_data_recovery/test_embedDB_var_data_recovery.cpp
@@ -227,7 +227,7 @@ void embedDB_variable_data_reloads_with_fifty_three_pages_of_data_correctly() {
     tearDown();
     initalizeEmbedDBFromFile();
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(15368, state->currentVarLoc, "EmbedDB currentVarLoc did not have the correct value after initializing variable data from a file with 106 pages of records.");
-    uint64_t expectedMinVarRecordId = 803;
+    uint32_t expectedMinVarRecordId = 803;
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedMinVarRecordId, &state->minVarRecordId, sizeof(uint32_t), "EmbedDB minVarRecordId did not have the correct value after initializing variable data from a file with 106 pages of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(2, state->numAvailVarPages, "EmbedDB numAvailVarPages did not have the correct value after initializing variable data from a file with 106 pages of records.");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(106, state->nextVarPageId, "EmbedDB nextVarPageId did not have the correct value after initializing variable data from a file with 106 pages of records.");

--- a/test/test_record_level_consistency/test_record_level_consistency.cpp
+++ b/test/test_record_level_consistency/test_record_level_consistency.cpp
@@ -80,8 +80,6 @@ void insertRecords(uint32_t startingKey, uint64_t startingData, uint32_t numReco
         int8_t result = embedDBPut(state, data, (void *)(data + 4));
         TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "EmbedDBPut did not correctly insert data (returned non-zero code)");
     }
-    uint32_t keyValue = *((uint32_t *)data);
-    printf("Data Value: %u", keyValue);
     free(data);
 }
 

--- a/test/test_var_data_record_level_consistency/test_var_data_record_level_consistency.cpp
+++ b/test/test_var_data_record_level_consistency/test_var_data_record_level_consistency.cpp
@@ -1,0 +1,111 @@
+#ifdef DIST
+#include "embedDB.h"
+#else
+#include "embedDB/embedDB.h"
+#include "embedDBUtility.h"
+#endif
+
+#if defined(MEMBOARD)
+#include "memboardTestSetup.h"
+#endif
+
+#if defined(MEGA)
+#include "megaTestSetup.h"
+#endif
+
+#if defined(DUE)
+#include "dueTestSetup.h"
+#endif
+
+#ifdef ARDUINO
+#include "SDFileInterface.h"
+#define getFileInterface getSDInterface
+#define setupFile setupSDFile
+#define tearDownFile tearDownSDFile
+#define DATA_FILE_PATH "dataFile.bin"
+#define VAR_DATA_FILE_PATH "varFile.bin"
+#else
+#include "desktopFileInterface.h"
+#define DATA_FILE_PATH "build/artifacts/dataFile.bin"
+#define VAR_DATA_FILE_PATH "build/artifacts/varFile.bin"
+#endif
+
+#include "unity.h"
+
+embedDBState *state;
+
+void setupEmbedDB(int8_t parameters) {
+    /* The setup below will result in having 42 records per page */
+    state = (embedDBState *)malloc(sizeof(embedDBState));
+    TEST_ASSERT_NOT_NULL_MESSAGE(state, "Unable to allocate embedDBState.");
+    state->keySize = 4;
+    state->dataSize = 8;
+    state->pageSize = 512;
+    state->bufferSizeInBlocks = 4;
+    state->numSplinePoints = 8;
+    state->buffer = malloc((size_t)state->bufferSizeInBlocks * state->pageSize);
+    TEST_ASSERT_NOT_NULL_MESSAGE(state->buffer, "Failed to allocate buffer for EmbedDB.");
+
+    /* configure EmbedDB storage */
+    state->fileInterface = getFileInterface();
+    char *dataFilePath = DATA_FILE_PATH;
+    char *varDataFilePath = 0;
+    state->dataFile = setupFile(dataFilePath);
+
+    state->numDataPages = 128;
+    state->numVarPages = 64;
+    state->eraseSizeInPages = 4;
+    state->parameters = parameters;
+    state->compareKey = int32Comparator;
+    state->compareData = int64Comparator;
+    int8_t result = embedDBInit(state, 1);
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "EmbedDB did not initialize correctly.");
+}
+
+void setUp() {
+    int8_t setupParamaters = EMBEDDB_RECORD_LEVEL_CONSISTENCY | EMBEDDB_RESET_DATA | EMBEDDB_USE_VDATA;
+    setupEmbedDB(setupParamaters);
+}
+
+void tearDown() {
+    free(state->buffer);
+    embedDBClose(state);
+    tearDownFile(state->dataFile);
+    free(state->fileInterface);
+    free(state);
+}
+
+void insertRecords(uint32_t startingKey, uint64_t startingData, void *variableData, uint32_t length, uint32_t numRecords) {
+    int8_t *data = (int8_t *)malloc(state->recordSize);
+    uint32_t key = startingKey;
+    uint64_t data = startingData;
+    for (uint32_t i = 0; i < numRecords; i++) {
+        int8_t result = embedDBPutVar(state, &key, &data, variableData, length);
+        TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "embedDBPutVar did not correctly insert data (returned non-zero code)");
+        key++;
+        data++;
+    }
+}
+
+int runUnityTests() {
+    UNITY_BEGIN();
+    return UNITY_END();
+}
+
+#ifdef ARDUINO
+
+void setup() {
+    delay(2000);
+    setupBoard();
+    runUnityTests();
+}
+
+void loop() {}
+
+#else
+
+int main() {
+    return runUnityTests();
+}
+
+#endif

--- a/test/test_var_data_record_level_consistency/test_var_data_record_level_consistency.cpp
+++ b/test/test_var_data_record_level_consistency/test_var_data_record_level_consistency.cpp
@@ -90,13 +90,13 @@ void insertRecords(uint32_t startingKey, uint64_t startingData, void *variableDa
     }
 }
 
-void insertRecordsCustomVarData(uint32_t startingKey, uint64_t startingData, uint32_t numRecords) {
+void insertRecordsCustomVarData(uint32_t startingKey, uint64_t startingData, uint32_t numRecords, uint32_t length) {
     uint32_t key = startingKey;
     uint64_t data = startingData;
-    char variableData[25];
+    char variableData[length];
     for (uint32_t i = 0; i < numRecords; i++) {
-        snprintf(variableData, 24, "Variable Data %u", key);
-        int8_t result = embedDBPutVar(state, &key, &data, variableData, 24);
+        snprintf(variableData, length, "Variable Data %u", key);
+        int8_t result = embedDBPutVar(state, &key, &data, variableData, length);
         TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "embedDBPutVar did not correctly insert data (returned non-zero code)");
         key++;
         data++;
@@ -124,7 +124,7 @@ void variable_data_record_level_consistency_records_should_be_readable() {
 
     /* Check that we can still query the remaining records */
     uint64_t recordData = 0;
-    char variableDataBuffer[13];
+    char variableDataBuffer[15];
     char expectedVariableData[] = "Database COD";
     char message[120];
     key = 955666;
@@ -139,7 +139,7 @@ void variable_data_record_level_consistency_records_should_be_readable() {
         uint32_t streamBytesRead = 0;
         snprintf(message, 120, "embedDBGetVar returned null stream for key %u.", key);
         TEST_ASSERT_NOT_NULL_MESSAGE(stream, message);
-        streamBytesRead = embedDBVarDataStreamRead(state, stream, variableDataBuffer, 12);
+        streamBytesRead = embedDBVarDataStreamRead(state, stream, variableDataBuffer, 15);
         snprintf(message, 120, "embedDBGetVar did not return correct data for a record inserted before reloading (key %u).", key);
         TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&data, &recordData, sizeof(uint64_t), message);
         TEST_ASSERT_EQUAL_UINT32_MESSAGE(12, streamBytesRead, "EmbedDB var data stream did not read the correct number of bytes.");
@@ -155,8 +155,7 @@ void variable_data_record_level_consistency_records_should_be_readable() {
 void variable_data_record_level_consistency_should_recover_64_records_correctly() {
     uint32_t key = 157557064;
     uint64_t data = 449130689;
-    char variableData[24];
-    insertRecordsCustomVarData(key, data, 64);
+    insertRecordsCustomVarData(key, data, 64, 24);
 
     /* tear down state and recover */
     tearDown();
@@ -172,7 +171,7 @@ void variable_data_record_level_consistency_should_recover_64_records_correctly(
 
     /* Check that we can still query the records inserted before recovery */
     uint64_t actualData = 0;
-    char actualVariableData[24];
+    char actualVariableData[25];
     char expectedVariableData[24];
     char message[120];
     uint32_t expectedKey = 157557064;
@@ -208,7 +207,7 @@ void variable_data_record_level_consistency_should_recover_64_records_correctly(
 void variable_data_record_level_consistency_should_recover_four_pages_data_records_correctly() {
     uint32_t key = 571933978;
     uint64_t data = 691272876;
-    insertRecordsCustomVarData(key, data, 124);
+    insertRecordsCustomVarData(key, data, 124, 24);
     embedDBFlush(state);
 
     /* tear down state and recover */
@@ -225,7 +224,7 @@ void variable_data_record_level_consistency_should_recover_four_pages_data_recor
 
     /* Check that we can still query the records inserted before recovery */
     uint64_t actualData = 0;
-    char actualVariableData[24];
+    char actualVariableData[25];
     char expectedVariableData[24];
     char message[120];
     uint32_t expectedKey = 571933978;
@@ -273,7 +272,7 @@ void variable_data_record_level_consistency_should_recover_four_pages_data_recor
 void variable_data_record_level_consistency_should_recover_71_pages_data_and_19_record_level_consistency_records() {
     uint32_t key = 85824389;
     uint64_t data = 46212944;
-    insertRecordsCustomVarData(key, data, 2218);
+    insertRecordsCustomVarData(key, data, 2218, 23);
 
     /* tear down state and recover */
     tearDown();
@@ -289,8 +288,8 @@ void variable_data_record_level_consistency_should_recover_71_pages_data_and_19_
 
     /* Check that we can query some record-level consistency and regular records */
     uint64_t actualData = 0;
-    char actualVariableData[24];
-    char expectedVariableData[24];
+    char actualVariableData[25];
+    char expectedVariableData[23];
     char message[120];
     uint32_t expectedKey = 85826577;
     uint64_t expectedData = 46215132;
@@ -307,10 +306,10 @@ void variable_data_record_level_consistency_should_recover_71_pages_data_and_19_
         streamBytesRead = embedDBVarDataStreamRead(state, stream, actualVariableData, 25);
         snprintf(message, 120, "embedDBGetVar did not return correct data for a record inserted before reloading (key %u).", expectedKey);
         TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedData, &actualData, sizeof(uint64_t), message);
-        TEST_ASSERT_EQUAL_UINT32_MESSAGE(24, streamBytesRead, "EmbedDB var data stream did not read the correct number of bytes.");
-        snprintf(expectedVariableData, 24, "Variable Data %u", expectedKey);
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(23, streamBytesRead, "EmbedDB var data stream did not read the correct number of bytes.");
+        snprintf(expectedVariableData, 23, "Variable Data %u", expectedKey);
         snprintf(message, 120, "embedDBGetVar did not return the correct variable data for key %u.", expectedKey);
-        TEST_ASSERT_EQUAL_CHAR_ARRAY_MESSAGE(expectedVariableData, actualVariableData, 24, message);
+        TEST_ASSERT_EQUAL_CHAR_ARRAY_MESSAGE(expectedVariableData, actualVariableData, 23, message);
         free(stream);
         stream = NULL;
         expectedKey++;
@@ -344,7 +343,7 @@ void variable_data_record_level_consistency_should_recover_variable_data_longer_
 
     /* Check that we can query records */
     uint64_t actualData = 0;
-    char actualVariableData[690];
+    char actualVariableData[700];
     char expectedVariableData[] = LONG_VARIABLE_DATA;
     char message[120];
     uint32_t expectedKey = 98208683;
@@ -359,7 +358,7 @@ void variable_data_record_level_consistency_should_recover_variable_data_longer_
         uint32_t streamBytesRead = 0;
         snprintf(message, 120, "embedDBGetVar returned null stream for key %u.", expectedKey);
         TEST_ASSERT_NOT_NULL_MESSAGE(stream, message);
-        streamBytesRead = embedDBVarDataStreamRead(state, stream, actualVariableData, 690);
+        streamBytesRead = embedDBVarDataStreamRead(state, stream, actualVariableData, 700);
         snprintf(message, 120, "embedDBGetVar did not return correct data for a record inserted before reloading (key %u).", expectedKey);
         TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expectedData, &actualData, sizeof(uint64_t), message);
         TEST_ASSERT_EQUAL_UINT32_MESSAGE(690, streamBytesRead, "EmbedDB var data stream did not read the correct number of bytes.");
@@ -381,15 +380,15 @@ void variable_data_record_level_consistency_should_recover_after_inserting_131_p
     /* 131 pages of data and 6 indidivudal records*/
     uint32_t key = 64454095;
     uint64_t data = 29636444;
-    char variableData[25];
+    char variableData[23];
     /* 1/4 of records have variable data */
     for (uint32_t i = 0; i < 4067; i++) {
         int8_t result = 0;
         if (i % 4 == 3) {
-            snprintf(variableData, 24, "Variable Data %u", key);
-            result = embedDBPutVar(state, &key, &data, variableData, 24);
+            snprintf(variableData, 23, "Variable Data %u", key);
+            result = embedDBPutVar(state, &key, &data, variableData, 23);
         } else {
-            embedDBPutVar(state, &key, &data, NULL, 24);
+            embedDBPutVar(state, &key, &data, NULL, 23);
         }
         TEST_ASSERT_EQUAL_INT8_MESSAGE(0, result, "embedDBPutVar did not correctly insert data (returned non-zero code)");
         key++;
@@ -410,8 +409,8 @@ void variable_data_record_level_consistency_should_recover_after_inserting_131_p
 
     /* Check that we can still query the records inserted before recovery */
     uint64_t actualData = 0;
-    char actualVariableData[24];
-    char expectedVariableData[24];
+    char actualVariableData[25];
+    char expectedVariableData[23];
     char message[120];
     uint32_t expectedKey = 64457843;
     uint64_t expectedData = 29640192;
@@ -445,10 +444,10 @@ void variable_data_record_level_consistency_should_recover_after_inserting_131_p
             snprintf(message, 120, "embedDBGetVar returned null stream for key %u.", expectedKey);
             TEST_ASSERT_NOT_NULL_MESSAGE(stream, message);
             streamBytesRead = embedDBVarDataStreamRead(state, stream, actualVariableData, 25);
-            TEST_ASSERT_EQUAL_UINT32_MESSAGE(24, streamBytesRead, "EmbedDB var data stream did not read the correct number of bytes.");
-            snprintf(expectedVariableData, 24, "Variable Data %u", expectedKey);
+            TEST_ASSERT_EQUAL_UINT32_MESSAGE(23, streamBytesRead, "EmbedDB var data stream did not read the correct number of bytes.");
+            snprintf(expectedVariableData, 23, "Variable Data %u", expectedKey);
             snprintf(message, 120, "embedDBGetVar did not return the correct variable data for key %u.", expectedKey);
-            TEST_ASSERT_EQUAL_CHAR_ARRAY_MESSAGE(expectedVariableData, actualVariableData, 24, message);
+            TEST_ASSERT_EQUAL_CHAR_ARRAY_MESSAGE(expectedVariableData, actualVariableData, 23, message);
             free(stream);
             stream = NULL;
         }

--- a/test/test_var_data_record_level_consistency/test_var_data_record_level_consistency.cpp
+++ b/test/test_var_data_record_level_consistency/test_var_data_record_level_consistency.cpp
@@ -49,8 +49,9 @@ void setupEmbedDB(int8_t parameters) {
     /* configure EmbedDB storage */
     state->fileInterface = getFileInterface();
     char *dataFilePath = DATA_FILE_PATH;
-    char *varDataFilePath = 0;
+    char *varDataFilePath = VAR_DATA_FILE_PATH;
     state->dataFile = setupFile(dataFilePath);
+    state->varFile = setupFile(varDataFilePath);
 
     state->numDataPages = 128;
     state->numVarPages = 64;
@@ -71,12 +72,12 @@ void tearDown() {
     free(state->buffer);
     embedDBClose(state);
     tearDownFile(state->dataFile);
+    tearDownFile(state->varFile);
     free(state->fileInterface);
     free(state);
 }
 
 void insertRecords(uint32_t startingKey, uint64_t startingData, void *variableData, uint32_t length, uint32_t numRecords) {
-    int8_t *data = (int8_t *)malloc(state->recordSize);
     uint32_t key = startingKey;
     uint64_t data = startingData;
     for (uint32_t i = 0; i < numRecords; i++) {
@@ -87,8 +88,56 @@ void insertRecords(uint32_t startingKey, uint64_t startingData, void *variableDa
     }
 }
 
+void variable_data_for_record_level_consistency_records_should_be_readable() {
+    /* insert 16 records into database with record-level consistency */
+    char variableData[] = "Database COD";
+    uint32_t key = 955666;
+    uint64_t data = 960651;
+    insertRecords(key, data, variableData, 12, 16);
+
+    /* tear down state and recover */
+    tearDown();
+    int8_t setupParameters = EMBEDDB_RECORD_LEVEL_CONSISTENCY | EMBEDDB_USE_VDATA;
+    setupEmbedDB(setupParameters);
+
+    /* Check that the state was correctly setup again */
+    TEST_ASSERT_EQUAL_INT8_MESSAGE(8, state->variableDataHeaderSize, "embedDBInit did not set the correct variableDataHeaderSize when recovering with variable data and record-level consistency.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(state->minVarRecordId, 955666, "embedDBInit did not set the correct minVarRecordID when recovering with variable data and record-level consistency.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(state->nextVarPageId, 16, "embedDBInit did not set the correct nextVarPageId when recovering with variable data and record-level consistency.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(state->numAvailVarPages, 48, "embedDBInit did not set the correct numAvailVarPages when recovering with variable data and record-level consistency.");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(8200, state->currentVarLoc, "embedDBInit did not set the correct currentVarLoc when recovering with variable data and record-level consistency.");
+
+    /* Check that we can still query the remaining records */
+    uint64_t recordData = 0;
+    char variableDataBuffer[13];
+    char expectedVariableData[] = "Database COD";
+    char message[120];
+    key = 955666;
+    data = 960651;
+    embedDBVarDataStream *stream = NULL;
+    /* Records inserted before reload */
+    for (int i = 0; i < 16; i++) {
+        int8_t getResult = embedDBGetVar(state, &key, &recordData, &stream);
+        snprintf(message, 120, "EmbedDB get encountered an error fetching the data for key %li.", key);
+        TEST_ASSERT_EQUAL_INT8_MESSAGE(0, getResult, message);
+        uint32_t streamBytesRead = 0;
+        snprintf(message, 120, "EmbedDB get var returned null stream for key %li.", key);
+        TEST_ASSERT_NOT_NULL_MESSAGE(stream, message);
+        streamBytesRead = embedDBVarDataStreamRead(state, stream, variableDataBuffer, 12);
+        snprintf(message, 120, "EmbedDB get did not return correct data for a record inserted before reloading (key %li).", key);
+        TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&data, &recordData, sizeof(uint64_t), message);
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(12, streamBytesRead, "EmbedDB var data stream did not read the correct number of bytes.");
+        snprintf(message, 120, "EmbedDB get var did not return the correct variable data for key %li.", key);
+        TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expectedVariableData, variableDataBuffer, 12, message);
+        key++;
+        data++;
+        free(stream);
+    }
+}
+
 int runUnityTests() {
     UNITY_BEGIN();
+    RUN_TEST(variable_data_for_record_level_consistency_records_should_be_readable);
     return UNITY_END();
 }
 


### PR DESCRIPTION
### Description
- Need to add support for record-level consistency for variable data.
- This is done by writing out the page as soon as you provide any variable data so it is immediately saved to storage.
- Additionally, the recovery algorithm needs to be updated to be platform-independent, similar to how the data recovery algorithm was changed.